### PR TITLE
Missing check for underlines in kmscon_font_attr_match

### DIFF
--- a/src/font.c
+++ b/src/font.c
@@ -130,6 +130,8 @@ bool kmscon_font_attr_match(const struct kmscon_font_attr *a1,
 		return false;
 	if (a1->italic != a2->italic)
 		return false;
+	if (a1->underline != a2->underline)
+		return false;
 	if (*a1->name && *a2->name && strcmp(a1->name, a2->name))
 		return false;
 


### PR DESCRIPTION
The function to evaluate if two font attributes are the same was missing a check for whether the two were both underlined. Incidentally, this fixed a problem I was having where the characters H, K, T, U, X, and j would all appear italicized.