### PR TITLE
[WIP] Initial support for 24bit fbdev

### DIFF
--- a/src/uterm_fbdev_internal.h
+++ b/src/uterm_fbdev_internal.h
@@ -55,6 +55,7 @@ struct fbdev_display {
 	unsigned int stride;
 
 	bool xrgb32;
+	bool rgb24;
 	bool rgb16;
 	unsigned int Bpp;
 	unsigned int off_r;

--- a/src/uterm_video.h
+++ b/src/uterm_video.h
@@ -100,6 +100,7 @@ enum uterm_video_format {
 	UTERM_FORMAT_GREY	= 0x01,
 	UTERM_FORMAT_XRGB32	= 0x02,
 	UTERM_FORMAT_RGB16	= 0x04,
+	UTERM_FORMAT_RGB24	= 0x08,
 };
 
 struct uterm_video_buffer {


### PR DESCRIPTION
This is necessary to provide output for cirrus.
While there is some DRM support available, it's too limited for kmscon's drm2d
and even then only supports 24bit out of the box.

Getting DRM with cirrus to work requires adding support for 24bit in the drm2d backend and adding a fallback for missing page flip support.