### PR TITLE
Force hashtable key to 64 bits

### DIFF
--- a/src/font_pango.c
+++ b/src/font_pango.c
@@ -131,8 +131,7 @@ static int get_glyph(struct face *face, struct kmscon_glyph **out,
 		return -ERANGE;
 
 	pthread_mutex_lock(&face->glyph_lock);
-	res = shl_hashtable_find(face->glyphs, (void**)&glyph,
-				 (void*)(uint64_t)id);
+	res = shl_hashtable_find(face->glyphs, (void**)&glyph, id);
 	pthread_mutex_unlock(&face->glyph_lock);
 	if (res) {
 		*out = glyph;
@@ -227,7 +226,7 @@ static int get_glyph(struct face *face, struct kmscon_glyph **out,
 	pango_ft2_render_layout_line(&bitmap, line, -rec.x, face->baseline);
 
 	pthread_mutex_lock(&face->glyph_lock);
-	ret = shl_hashtable_insert(face->glyphs, (void*)(uint64_t)id, glyph);
+	ret = shl_hashtable_insert(face->glyphs, id, glyph);
 	pthread_mutex_unlock(&face->glyph_lock);
 	if (ret) {
 		log_error("cannot add glyph to hashtable");
@@ -299,7 +298,7 @@ static int manager_get_face(struct face **out, struct kmscon_font_attr *attr)
 	}
 
 	ret = shl_hashtable_new(&face->glyphs, shl_direct_hash,
-				shl_direct_equal, NULL, free_glyph);
+				shl_direct_equal, free_glyph);
 	if (ret) {
 		log_error("cannot allocate hashtable");
 		goto err_lock;

--- a/src/font_unifont.c
+++ b/src/font_unifont.c
@@ -118,14 +118,13 @@ static int find_glyph(uint32_t ch, const struct kmscon_glyph **out)
 
 	if (!cache) {
 		ret = shl_hashtable_new(&cache, shl_direct_hash,
-					shl_direct_equal, NULL, free_glyph);
+					shl_direct_equal, free_glyph);
 		if (ret) {
 			log_error("cannot create unifont hashtable: %d", ret);
 			goto out_unlock;
 		}
 	} else {
-		res = shl_hashtable_find(cache, (void**)out,
-					 (void*)(uint64_t)ch);
+		res = shl_hashtable_find(cache, (void**)out, ch);
 		if (res) {
 			ret = 0;
 			goto out_unlock;
@@ -187,7 +186,7 @@ static int find_glyph(uint32_t ch, const struct kmscon_glyph **out)
 		unfold(&g->buf.data[i * 8 + 7], d->data[i] & 0x01);
 	}
 
-	ret = shl_hashtable_insert(cache, (void*)(uint64_t)ch, g);
+	ret = shl_hashtable_insert(cache, ch, g);
 	if (ret) {
 		log_error("cannot insert glyph into glyph-cache: %d", ret);
 		goto err_data;

--- a/src/text_gltex.c
+++ b/src/text_gltex.c
@@ -162,14 +162,12 @@ static int gltex_set(struct kmscon_text *txt)
 	shl_dlist_init(&gt->atlases);
 
 	ret = shl_hashtable_new(&gt->glyphs, shl_direct_hash,
-				shl_direct_equal, NULL,
-				free_glyph);
+				shl_direct_equal, free_glyph);
 	if (ret)
 		return ret;
 
 	ret = shl_hashtable_new(&gt->bold_glyphs, shl_direct_hash,
-				shl_direct_equal, NULL,
-				free_glyph);
+				shl_direct_equal, free_glyph);
 	if (ret)
 		goto err_htable;
 
@@ -411,8 +409,7 @@ static int find_glyph(struct kmscon_text *txt, struct glyph **out,
 	else
 		font->attr.italic = false;
 
-	res = shl_hashtable_find(gtable, (void**)&glyph,
-				 (void*)(uint64_t)id);
+	res = shl_hashtable_find(gtable, (void**)&glyph, id);
 	if (res) {
 		*out = glyph;
 		return 0;
@@ -515,7 +512,7 @@ static int find_glyph(struct kmscon_text *txt, struct glyph **out,
 	glyph->atlas = atlas;
 	glyph->texoff = atlas->fill;
 
-	ret = shl_hashtable_insert(gtable, (void*)(uint64_t)id, glyph);
+	ret = shl_hashtable_insert(gtable, id, glyph);
 	if (ret)
 		goto err_free;
 

--- a/src/text_pixman.c
+++ b/src/text_pixman.c
@@ -185,14 +185,12 @@ static int tp_set(struct kmscon_text *txt)
 	}
 
 	ret = shl_hashtable_new(&tp->glyphs, shl_direct_hash,
-				shl_direct_equal, NULL,
-				free_glyph);
+				shl_direct_equal, free_glyph);
 	if (ret)
 		goto err_white;
 
 	ret = shl_hashtable_new(&tp->bold_glyphs, shl_direct_hash,
-				shl_direct_equal, NULL,
-				free_glyph);
+				shl_direct_equal, free_glyph);
 	if (ret)
 		goto err_htable;
 
@@ -292,8 +290,7 @@ static int find_glyph(struct kmscon_text *txt, struct tp_glyph **out,
 	else
 		font->attr.italic = false;
 
-	res = shl_hashtable_find(gtable, (void**)&glyph,
-				 (void*)(uint64_t)id);
+	res = shl_hashtable_find(gtable, (void**)&glyph, id);
 	if (res) {
 		*out = glyph;
 		return 0;
@@ -361,7 +358,7 @@ static int find_glyph(struct kmscon_text *txt, struct tp_glyph **out,
 		goto err_free;
 	}
 
-	ret = shl_hashtable_insert(gtable, (void*)(uint64_t)id, glyph);
+	ret = shl_hashtable_insert(gtable, id, glyph);
 	if (ret)
 		goto err_pixman;
 


### PR DESCRIPTION
It is used to store 64-bit IDs, but on 32-bit systems `void*` is only 32 bits wide.