### PR TITLE
Actually make embedded data work

### DIFF
--- a/src/font_unifont.c
+++ b/src/font_unifont.c
@@ -62,8 +62,8 @@ struct unifont_data {
 	uint8_t data[32];
 } __attribute__((__packed__));
 
-extern const char _binary_src_font_unifont_data_bin_start[];
-extern const char _binary_src_font_unifont_data_bin_end[];
+extern const char *_binary_src_font_unifont_data_bin_start;
+extern const char *_binary_src_font_unifont_data_bin_end;
 
 /*
  * Global glyph cache

--- a/src/font_unifont.c
+++ b/src/font_unifont.c
@@ -64,6 +64,7 @@ struct unifont_data {
 
 extern const char *_binary_src_font_unifont_data_bin_start;
 extern const char *_binary_src_font_unifont_data_bin_end;
+extern const size_t _binary_src_font_unifont_data_bin_size;
 
 /*
  * Global glyph cache

--- a/src/font_unifont.c
+++ b/src/font_unifont.c
@@ -210,13 +210,10 @@ static int kmscon_font_unifont_init(struct kmscon_font *out,
 				    const struct kmscon_font_attr *attr)
 {
 	static const char name[] = "static-unifont";
-	const struct unifont_data *start, *end;
 
 	log_debug("loading static unifont font");
 
-	start = (const struct unifont_data*)_binary_src_font_unifont_data_bin_start;
-	end = (const struct unifont_data*)_binary_src_font_unifont_data_bin_end;
-	if (start == end) {
+	if (_binary_src_font_unifont_data_bin_size == 0) {
 		log_error("unifont glyph information not found in binary");
 		return -EFAULT;
 	}

--- a/src/text_gltex.c
+++ b/src/text_gltex.c
@@ -141,10 +141,10 @@ static void free_glyph(void *data)
 	free(glyph);
 }
 
-extern const char _binary_src_text_gltex_atlas_vert_bin_start[];
-extern const char _binary_src_text_gltex_atlas_vert_bin_end[];
-extern const char _binary_src_text_gltex_atlas_frag_bin_start[];
-extern const char _binary_src_text_gltex_atlas_frag_bin_end[];
+extern const char *_binary_src_text_gltex_atlas_vert_bin_start;
+extern const char *_binary_src_text_gltex_atlas_vert_bin_end;
+extern const char *_binary_src_text_gltex_atlas_frag_bin_start;
+extern const char *_binary_src_text_gltex_atlas_frag_bin_end;
 
 static int gltex_set(struct kmscon_text *txt)
 {

--- a/src/text_gltex.c
+++ b/src/text_gltex.c
@@ -181,9 +181,9 @@ static int gltex_set(struct kmscon_text *txt)
 	}
 
 	vert = _binary_src_text_gltex_atlas_vert_bin_start;
-	vlen = _binary_src_text_gltex_atlas_vert_bin_end - vert;
+	vlen = _binary_src_text_gltex_atlas_vert_bin_size;
 	frag = _binary_src_text_gltex_atlas_frag_bin_start;
-	flen = _binary_src_text_gltex_atlas_frag_bin_end - frag;
+	flen = _binary_src_text_gltex_atlas_frag_bin_size;
 	gl_clear_error();
 
 	ret = gl_shader_new(&gt->shader, vert, vlen, frag, flen, attr, 4,

--- a/src/text_gltex.c
+++ b/src/text_gltex.c
@@ -143,8 +143,10 @@ static void free_glyph(void *data)
 
 extern const char *_binary_src_text_gltex_atlas_vert_bin_start;
 extern const char *_binary_src_text_gltex_atlas_vert_bin_end;
+extern const size_t _binary_src_text_gltex_atlas_vert_bin_size;
 extern const char *_binary_src_text_gltex_atlas_frag_bin_start;
 extern const char *_binary_src_text_gltex_atlas_frag_bin_end;
+extern const size_t _binary_src_text_gltex_atlas_frag_bin_size;
 
 static int gltex_set(struct kmscon_text *txt)
 {

--- a/src/uterm_drm3d_render.c
+++ b/src/uterm_drm3d_render.c
@@ -93,17 +93,17 @@ static int init_shaders(struct uterm_video *video)
 	v3d->sinit = 1;
 
 	blend_vert = _binary_src_uterm_drm3d_blend_vert_bin_start;
-	blend_vlen = _binary_src_uterm_drm3d_blend_vert_bin_end - blend_vert;
+	blend_vlen = _binary_src_uterm_drm3d_blend_vert_bin_size;
 	blend_frag = _binary_src_uterm_drm3d_blend_frag_bin_start;
-	blend_flen = _binary_src_uterm_drm3d_blend_frag_bin_end - blend_frag;
+	blend_flen = _binary_src_uterm_drm3d_blend_frag_bin_size;
 	blit_vert = _binary_src_uterm_drm3d_blit_vert_bin_start;
-	blit_vlen = _binary_src_uterm_drm3d_blit_vert_bin_end - blit_vert;
+	blit_vlen = _binary_src_uterm_drm3d_blit_vert_bin_size;
 	blit_frag = _binary_src_uterm_drm3d_blit_frag_bin_start;
-	blit_flen = _binary_src_uterm_drm3d_blit_frag_bin_end - blit_frag;
+	blit_flen = _binary_src_uterm_drm3d_blit_frag_bin_size;
 	fill_vert = _binary_src_uterm_drm3d_fill_vert_bin_start;
-	fill_vlen = _binary_src_uterm_drm3d_fill_vert_bin_end - fill_vert;
+	fill_vlen = _binary_src_uterm_drm3d_fill_vert_bin_size;
 	fill_frag = _binary_src_uterm_drm3d_fill_frag_bin_start;
-	fill_flen = _binary_src_uterm_drm3d_fill_frag_bin_end - fill_frag;
+	fill_flen = _binary_src_uterm_drm3d_fill_frag_bin_size;
 
 	ret = gl_shader_new(&v3d->fill_shader, fill_vert, fill_vlen,
 			    fill_frag, fill_flen, fill_attr, 2, log_llog,

--- a/src/uterm_drm3d_render.c
+++ b/src/uterm_drm3d_render.c
@@ -56,16 +56,22 @@
 
 extern const char *_binary_src_uterm_drm3d_blend_vert_bin_start;
 extern const char *_binary_src_uterm_drm3d_blend_vert_bin_end;
+extern const size_t _binary_src_uterm_drm3d_blend_vert_bin_size;
 extern const char *_binary_src_uterm_drm3d_blend_frag_bin_start;
 extern const char *_binary_src_uterm_drm3d_blend_frag_bin_end;
+extern const size_t _binary_src_uterm_drm3d_blend_frag_bin_size;
 extern const char *_binary_src_uterm_drm3d_blit_vert_bin_start;
 extern const char *_binary_src_uterm_drm3d_blit_vert_bin_end;
+extern const size_t _binary_src_uterm_drm3d_blit_vert_bin_size;
 extern const char *_binary_src_uterm_drm3d_blit_frag_bin_start;
 extern const char *_binary_src_uterm_drm3d_blit_frag_bin_end;
+extern const size_t _binary_src_uterm_drm3d_blit_frag_bin_size;
 extern const char *_binary_src_uterm_drm3d_fill_vert_bin_start;
 extern const char *_binary_src_uterm_drm3d_fill_vert_bin_end;
+extern const size_t _binary_src_uterm_drm3d_fill_vert_bin_size;
 extern const char *_binary_src_uterm_drm3d_fill_frag_bin_start;
 extern const char *_binary_src_uterm_drm3d_fill_frag_bin_end;
+extern const size_t _binary_src_uterm_drm3d_fill_frag_bin_size;
 
 static int init_shaders(struct uterm_video *video)
 {

--- a/src/uterm_drm3d_render.c
+++ b/src/uterm_drm3d_render.c
@@ -54,18 +54,18 @@
 
 #define LOG_SUBSYSTEM "uterm_drm3d_render"
 
-extern const char _binary_src_uterm_drm3d_blend_vert_bin_start[];
-extern const char _binary_src_uterm_drm3d_blend_vert_bin_end[];
-extern const char _binary_src_uterm_drm3d_blend_frag_bin_start[];
-extern const char _binary_src_uterm_drm3d_blend_frag_bin_end[];
-extern const char _binary_src_uterm_drm3d_blit_vert_bin_start[];
-extern const char _binary_src_uterm_drm3d_blit_vert_bin_end[];
-extern const char _binary_src_uterm_drm3d_blit_frag_bin_start[];
-extern const char _binary_src_uterm_drm3d_blit_frag_bin_end[];
-extern const char _binary_src_uterm_drm3d_fill_vert_bin_start[];
-extern const char _binary_src_uterm_drm3d_fill_vert_bin_end[];
-extern const char _binary_src_uterm_drm3d_fill_frag_bin_start[];
-extern const char _binary_src_uterm_drm3d_fill_frag_bin_end[];
+extern const char *_binary_src_uterm_drm3d_blend_vert_bin_start;
+extern const char *_binary_src_uterm_drm3d_blend_vert_bin_end;
+extern const char *_binary_src_uterm_drm3d_blend_frag_bin_start;
+extern const char *_binary_src_uterm_drm3d_blend_frag_bin_end;
+extern const char *_binary_src_uterm_drm3d_blit_vert_bin_start;
+extern const char *_binary_src_uterm_drm3d_blit_vert_bin_end;
+extern const char *_binary_src_uterm_drm3d_blit_frag_bin_start;
+extern const char *_binary_src_uterm_drm3d_blit_frag_bin_end;
+extern const char *_binary_src_uterm_drm3d_fill_vert_bin_start;
+extern const char *_binary_src_uterm_drm3d_fill_vert_bin_end;
+extern const char *_binary_src_uterm_drm3d_fill_frag_bin_start;
+extern const char *_binary_src_uterm_drm3d_fill_frag_bin_end;
 
 static int init_shaders(struct uterm_video *video)
 {

--- a/src/uterm_input_uxkb.c
+++ b/src/uterm_input_uxkb.c
@@ -42,6 +42,7 @@
 
 extern const char *_binary_src_uterm_input_fallback_xkb_bin_start;
 extern const char *_binary_src_uterm_input_fallback_xkb_bin_end;
+extern const size_t _binary_src_uterm_input_fallback_xkb_bin_size;
 
 static void uxkb_log(struct xkb_context *context, enum xkb_log_level level,
 		     const char *format, va_list args)

--- a/src/uterm_input_uxkb.c
+++ b/src/uterm_input_uxkb.c
@@ -40,8 +40,8 @@
 
 #define LLOG_SUBSYSTEM "uterm_uxkb"
 
-extern const char _binary_src_uterm_input_fallback_xkb_bin_start[];
-extern const char _binary_src_uterm_input_fallback_xkb_bin_end[];
+extern const char *_binary_src_uterm_input_fallback_xkb_bin_start;
+extern const char *_binary_src_uterm_input_fallback_xkb_bin_end;
 
 static void uxkb_log(struct xkb_context *context, enum xkb_log_level level,
 		     const char *format, va_list args)


### PR DESCRIPTION
My PR in #32 actually made kmscon non-functional. The program was unable to load the embedded data.

This is my fault for not changing the declarations in the source files and not testing my final version. I have now tested this and everything works as it should again.

While I was in the area, I also took advantage of the known size of the embedded data in several places.