### PR TITLE
Add Compose support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -47,7 +47,7 @@ LT_INIT
 # Required pkg-config dependencies
 #
 
-PKG_CHECK_MODULES([XKBCOMMON], [xkbcommon])
+PKG_CHECK_MODULES([XKBCOMMON], [xkbcommon >= 0.5.0])
 AC_SUBST(XKBCOMMON_CFLAGS)
 AC_SUBST(XKBCOMMON_LIBS)
 

--- a/docs/man/kmscon.xml
+++ b/docs/man/kmscon.xml
@@ -290,6 +290,23 @@
       </varlistentry>
 
       <varlistentry>
+        <term><option>--xkb-compose-file {file}</option></term>
+        <listitem>
+          <para>Path to a single predefined compose file. An empty path "" is
+                interpreted as using the default compose file. The default
+                compose file search order is described in
+                <citerefentry><refentrytitle>Compose</refentrytitle><manvolnum>5</manvolnum></citerefentry>.
+                The locale is determined from the first of
+                <envar>LC_ALL</envar>, <envar>LC_CTYPE</envar>, or
+                <envar>LANG</envar> that's set to a non-empty value. If the
+                locale cannot be determined, <literal>C</literal> is assumed. If
+                no compose file is found, composing is disabled. (default:
+                search the compose file corresponding to the current
+                locale)</para>
+        </listitem>
+      </varlistentry>
+
+      <varlistentry>
         <term><option>--xkb-repeat-delay {delay}</option></term>
         <listitem>
           <para>Delay after key was pressed until key-repeat starts (in
@@ -620,7 +637,8 @@
     <title>See Also</title>
     <para>
       <citerefentry><refentrytitle>kmscon.conf</refentrytitle><manvolnum>5</manvolnum></citerefentry>,
-      <citerefentry><refentrytitle>console</refentrytitle><manvolnum>4</manvolnum></citerefentry>
+      <citerefentry><refentrytitle>console</refentrytitle><manvolnum>4</manvolnum></citerefentry>,
+      <citerefentry><refentrytitle>Compose</refentrytitle><manvolnum>5</manvolnum></citerefentry>
     </para>
   </refsect1>
 </refentry>

--- a/src/kmscon_conf.c
+++ b/src/kmscon_conf.c
@@ -106,6 +106,8 @@ static void print_help()
 		"\t    --xkb-options <options>    [-]  Set XkbOptions for input devices\n"
 		"\t    --xkb-keymap <FILE>        [-]  Use a predefined keymap for\n"
 		"\t                                    input devices\n"
+		"\t    --xkb-compose-file <FILE>  [-]  Use a predefined compose file for\n"
+		"\t                                    input devices\n"
 		"\t    --xkb-repeat-delay <msecs> [250]\n"
 		"\t                                 Initial delay for key-repeat in ms\n"
 		"\t    --xkb-repeat-rate <msecs>  [50]\n"
@@ -576,6 +578,7 @@ int kmscon_conf_new(struct conf_ctx **out)
 		CONF_OPTION_STRING(0, "xkb-variant", &conf->xkb_variant, ""),
 		CONF_OPTION_STRING(0, "xkb-options", &conf->xkb_options, ""),
 		CONF_OPTION_STRING(0, "xkb-keymap", &conf->xkb_keymap, ""),
+		CONF_OPTION_STRING(0, "xkb-compose-file", &conf->xkb_compose_file, ""),
 		CONF_OPTION_UINT(0, "xkb-repeat-delay", &conf->xkb_repeat_delay, 250),
 		CONF_OPTION_UINT(0, "xkb-repeat-rate", &conf->xkb_repeat_rate, 50),
 

--- a/src/kmscon_conf.h
+++ b/src/kmscon_conf.h
@@ -104,6 +104,8 @@ struct kmscon_conf_t {
 	char *xkb_options;
 	/* input predefined KBD keymap */
 	char *xkb_keymap;
+	/* input predefined KBD compose file */
+	char *xkb_compose_file;
 	/* keyboard key-repeat delay */
 	unsigned int xkb_repeat_delay;
 	/* keyboard key-repeat rate */

--- a/src/kmscon_seat.c
+++ b/src/kmscon_seat.c
@@ -682,7 +682,8 @@ int kmscon_seat_new(struct kmscon_seat **out,
 	struct kmscon_seat *seat;
 	int ret;
 	const char *locale;
-	char *keymap;
+	char *keymap, *compose_file;
+	size_t compose_file_len;
 
 	if (!out || !eloop || !vtm || !seatname)
 		return -EINVAL;
@@ -732,12 +733,23 @@ int kmscon_seat_new(struct kmscon_seat **out,
 				  seat->conf->xkb_keymap, ret);
 	}
 
+	compose_file = NULL;
+	compose_file_len = 0;
+	if (seat->conf->xkb_compose_file && *seat->conf->xkb_compose_file) {
+		ret = shl_read_file(seat->conf->xkb_compose_file,
+				    &compose_file, &compose_file_len);
+		if (ret)
+			log_error("cannot read compose file %s: %d",
+				  seat->conf->xkb_compose_file, ret);
+	}
+
 	ret = uterm_input_new(&seat->input, seat->eloop,
 			      seat->conf->xkb_model,
 			      seat->conf->xkb_layout,
 			      seat->conf->xkb_variant,
 			      seat->conf->xkb_options,
-			      locale, keymap,
+			      locale, keymap, compose_file,
+			      compose_file_len,
 			      seat->conf->xkb_repeat_delay,
 			      seat->conf->xkb_repeat_rate,
 			      log_llog, NULL);

--- a/src/uterm_input.c
+++ b/src/uterm_input.c
@@ -227,6 +227,8 @@ int uterm_input_new(struct uterm_input **out,
 		    const char *options,
 		    const char *locale,
 		    const char *keymap,
+		    const char *compose_file,
+		    size_t compose_file_len,
 		    unsigned int repeat_delay,
 		    unsigned int repeat_rate,
 		    uterm_input_log_t log,
@@ -264,7 +266,7 @@ int uterm_input_new(struct uterm_input **out,
 		goto err_free;
 
 	ret = uxkb_desc_init(input, model, layout, variant, options, locale,
-			     keymap);
+			     keymap, compose_file, compose_file_len);
 	if (ret)
 		goto err_hook;
 

--- a/src/uterm_input.c
+++ b/src/uterm_input.c
@@ -225,6 +225,7 @@ int uterm_input_new(struct uterm_input **out,
 		    const char *layout,
 		    const char *variant,
 		    const char *options,
+		    const char *locale,
 		    const char *keymap,
 		    unsigned int repeat_delay,
 		    unsigned int repeat_rate,
@@ -262,7 +263,8 @@ int uterm_input_new(struct uterm_input **out,
 	if (ret)
 		goto err_free;
 
-	ret = uxkb_desc_init(input, model, layout, variant, options, keymap);
+	ret = uxkb_desc_init(input, model, layout, variant, options, locale,
+			     keymap);
 	if (ret)
 		goto err_hook;
 

--- a/src/uterm_input.h
+++ b/src/uterm_input.h
@@ -81,6 +81,7 @@ typedef void (*uterm_input_cb) (struct uterm_input *input,
 int uterm_input_new(struct uterm_input **out, struct ev_eloop *eloop,
 		    const char *model, const char *layout, const char *variant,
 		    const char *options, const char *locale, const char *keymap,
+		    const char *compose_file, size_t compose_file_len,
 		    unsigned int repeat_delay, unsigned int repeat_rate,
 		    uterm_input_log_t log, void *log_data);
 void uterm_input_ref(struct uterm_input *input);

--- a/src/uterm_input.h
+++ b/src/uterm_input.h
@@ -80,7 +80,7 @@ typedef void (*uterm_input_cb) (struct uterm_input *input,
 
 int uterm_input_new(struct uterm_input **out, struct ev_eloop *eloop,
 		    const char *model, const char *layout, const char *variant,
-		    const char *options, const char *keymap,
+		    const char *options, const char *locale, const char *keymap,
 		    unsigned int repeat_delay, unsigned int repeat_rate,
 		    uterm_input_log_t log, void *log_data);
 void uterm_input_ref(struct uterm_input *input);

--- a/src/uterm_input_internal.h
+++ b/src/uterm_input_internal.h
@@ -53,6 +53,7 @@ struct uterm_input_dev {
 	char *node;
 	struct ev_fd *fd;
 	struct xkb_state *state;
+	struct xkb_compose_state *compose_state;
 	/* Used in sleep/wake up to store the key's pressed/released state. */
 	char key_state_bits[SHL_DIV_ROUND_UP(KEY_CNT, CHAR_BIT)];
 

--- a/src/uterm_input_internal.h
+++ b/src/uterm_input_internal.h
@@ -76,6 +76,7 @@ struct uterm_input {
 	struct shl_hook *hook;
 	struct xkb_context *ctx;
 	struct xkb_keymap *keymap;
+	struct xkb_compose_table *compose_table;
 
 	struct shl_dlist devices;
 };
@@ -90,6 +91,7 @@ int uxkb_desc_init(struct uterm_input *input,
 		   const char *layout,
 		   const char *variant,
 		   const char *options,
+		   const char *locale,
 		   const char *keymap);
 void uxkb_desc_destroy(struct uterm_input *input);
 

--- a/src/uterm_input_internal.h
+++ b/src/uterm_input_internal.h
@@ -92,7 +92,9 @@ int uxkb_desc_init(struct uterm_input *input,
 		   const char *variant,
 		   const char *options,
 		   const char *locale,
-		   const char *keymap);
+		   const char *keymap,
+		   const char *compose_file,
+		   size_t compose_file_len);
 void uxkb_desc_destroy(struct uterm_input *input);
 
 int uxkb_dev_init(struct uterm_input_dev *dev);

--- a/src/uterm_input_uxkb.c
+++ b/src/uterm_input_uxkb.c
@@ -231,6 +231,15 @@ int uxkb_dev_init(struct uterm_input_dev *dev)
 		goto err_timer;
 	}
 
+	if (dev->input->compose_table) {
+		dev->compose_state = xkb_compose_state_new(
+						dev->input->compose_table,
+						0);
+		if (!dev->compose_state)
+			llog_warn(dev->input, "cannot create compose state, "
+				  "disabling compose support");
+	}
+
 	return 0;
 
 err_timer:
@@ -240,6 +249,7 @@ err_timer:
 
 void uxkb_dev_destroy(struct uterm_input_dev *dev)
 {
+	xkb_compose_state_unref(dev->compose_state);
 	xkb_state_unref(dev->state);
 	ev_eloop_rm_timer(dev->repeat_timer);
 }
@@ -416,18 +426,87 @@ int uxkb_dev_process(struct uterm_input_dev *dev,
 		     uint16_t key_state, uint16_t code)
 {
 	struct xkb_state *state;
+	struct xkb_compose_state *compose_state;
 	xkb_keycode_t keycode;
 	const xkb_keysym_t *keysyms;
+	xkb_keysym_t one_sym;
 	int num_keysyms, ret;
+	enum xkb_compose_status compose_status;
 	enum xkb_state_component changed;
 
 	if (key_state == KEY_REPEATED)
 		return -ENOKEY;
 
 	state = dev->state;
+	compose_state = dev->compose_state;
 	keycode = code + EVDEV_KEYCODE_OFFSET;
 
+	/*
+	 * To summarize the following convoluted logic:
+	 *
+	 * - single key press may produce one or more keysyms
+	 * - if num_keysyms == 1,
+	 *     + use get_one_sym to handle the maybe present LOCK mod
+	 *     + use the resulting one_sym to feed the compose_state
+	 *     + if the keysym completes a compose sequence,
+	 *         * compose_state will either produce one keysym, which is set
+	 *           back to one_sym, or
+	 *         * compose_state will produce NoSymbol, which is treated as a
+	 *           cancelled compose sequence
+	 *     + if the keysym completes or cancels a sequence, reset
+	 *       compose_state
+	 * - if num_keysyms != 1,
+	 *     + LOCK mod translation doesn't make sense, so skip that
+	 *     + compose_state is fed NoSymbol per documentation and the result
+	 *       is basically ignored
+	 * - update xkb state after querying keysyms per documentation
+	 * - if in the process of composing or if the composing was cancelled by
+	 *   the key press, stop here
+	 * - otherwise process events with keysyms and num_keysyms
+	 *
+	 * Some background on compose handling:
+	 * - https://github.com/xkbcommon/libxkbcommon/issues/4
+	 */
+
 	num_keysyms = xkb_state_key_get_syms(state, keycode, &keysyms);
+
+	one_sym = XKB_KEY_NoSymbol;
+	if (num_keysyms == 1) {
+		/* See: https://bugs.freedesktop.org/show_bug.cgi?id=67167 */
+		one_sym = xkb_state_key_get_one_sym(state, keycode);
+		keysyms = &one_sym;
+	}
+
+	compose_status = XKB_COMPOSE_NOTHING;
+	if (compose_state && key_state == KEY_PRESSED) {
+		/* XKB_KEY_NoSymbol cancels the current compose sequence. */
+		xkb_compose_state_feed(compose_state, one_sym);
+
+		compose_status = xkb_compose_state_get_status(compose_state);
+
+		if (compose_status == XKB_COMPOSE_COMPOSED) {
+			one_sym = xkb_compose_state_get_one_sym(compose_state);
+			if (one_sym == XKB_KEY_NoSymbol) {
+				/*
+				 * It is possible that the sequence only
+				 * specifies an utf8 string and not a keysym.
+				 * Treat this is cancelled, as the rest of the
+				 * system can not handle it.
+				 */
+				compose_status = XKB_COMPOSE_CANCELLED;
+			}
+		}
+
+		/*
+		 * Modifiers are legal key presses, but do not change the
+		 * compose_state. If the state is not reset after a sequence is
+		 * completed, holding down a modifier after composing repeats
+		 * the last composed sequence.
+		 */
+		if (compose_status == XKB_COMPOSE_COMPOSED ||
+		    compose_status == XKB_COMPOSE_CANCELLED)
+			xkb_compose_state_reset(compose_state);
+	}
 
 	changed = 0;
 	if (key_state == KEY_PRESSED)
@@ -439,6 +518,10 @@ int uxkb_dev_process(struct uterm_input_dev *dev,
 		uxkb_dev_update_keyboard_leds(dev);
 
 	if (num_keysyms <= 0)
+		return -ENOKEY;
+
+	if (compose_status == XKB_COMPOSE_COMPOSING ||
+	    compose_status == XKB_COMPOSE_CANCELLED)
 		return -ENOKEY;
 
 	ret = uxkb_dev_fill_event(dev, &dev->event, keycode, num_keysyms,
@@ -513,4 +596,7 @@ void uxkb_dev_wake_up(struct uterm_input_dev *dev)
 	}
 
 	uxkb_dev_update_keyboard_leds(dev);
+
+	if (dev->compose_state)
+		xkb_compose_state_reset(dev->compose_state);
 }

--- a/src/uterm_input_uxkb.c
+++ b/src/uterm_input_uxkb.c
@@ -88,7 +88,9 @@ int uxkb_desc_init(struct uterm_input *input,
 		   const char *variant,
 		   const char *options,
 		   const char *locale,
-		   const char *keymap)
+		   const char *keymap,
+		   const char *compose_file,
+		   size_t compose_file_len)
 {
 	int ret;
 	struct xkb_rule_names rmlvo = {
@@ -160,6 +162,24 @@ int uxkb_desc_init(struct uterm_input *input,
 	} else {
 		llog_debug(input, "new keyboard description (%s, %s, %s, %s)",
 			   model, layout, variant, options);
+	}
+
+	if (compose_file && *compose_file) {
+		input->compose_table = xkb_compose_table_new_from_buffer(
+					input->ctx,
+					compose_file,
+					compose_file_len,
+					locale,
+					XKB_COMPOSE_FORMAT_TEXT_V1,
+					0);
+
+		if (input->compose_table) {
+			llog_debug(input,
+				   "new compose table from memory");
+		} else {
+			llog_warn(input, "cannot parse compose table, "
+				  "reverting to default");
+		}
 	}
 
 	if (!input->compose_table) {

--- a/tests/test_input.c
+++ b/tests/test_input.c
@@ -52,6 +52,7 @@ struct {
 	char *xkb_layout;
 	char *xkb_variant;
 	char *xkb_options;
+	char *locale;
 	char *xkb_keymap;
 } input_conf;
 
@@ -130,6 +131,7 @@ static void monitor_event(struct uterm_monitor *mon,
 				      input_conf.xkb_layout,
 				      input_conf.xkb_variant,
 				      input_conf.xkb_options,
+				      input_conf.locale,
 				      keymap,
 				      0, 0, log_llog, NULL);
 		if (ret)
@@ -179,6 +181,7 @@ static void print_help()
 		"\t    --xkb-layout <layout>   [-]     Set XkbLayout for input devices\n"
 		"\t    --xkb-variant <variant> [-]     Set XkbVariant for input devices\n"
 		"\t    --xkb-options <options> [-]     Set XkbOptions for input devices\n"
+		"\t    --locale <locale>       [-]     Set locale for input devices\n"
 		"\t    --xkb-keymap <FILE>     [-]     Use a predefined keymap for\n"
 		"\t                                    input devices\n",
 		"test_input");
@@ -198,6 +201,7 @@ struct conf_option options[] = {
 	CONF_OPTION_STRING(0, "xkb-layout", &input_conf.xkb_layout, ""),
 	CONF_OPTION_STRING(0, "xkb-variant", &input_conf.xkb_variant, ""),
 	CONF_OPTION_STRING(0, "xkb-options", &input_conf.xkb_options, ""),
+	CONF_OPTION_STRING(0, "locale", &input_conf.locale, "C"),
 	CONF_OPTION_STRING(0, "xkb-keymap", &input_conf.xkb_keymap, ""),
 };
 

--- a/tests/test_vt.c
+++ b/tests/test_vt.c
@@ -113,7 +113,7 @@ int main(int argc, char **argv)
 	if (ret)
 		goto err_exit;
 
-	ret = uterm_input_new(&input, eloop, "", "", "", "", "", 0, 0,
+	ret = uterm_input_new(&input, eloop, "", "", "", "", "C", "", 0, 0,
 			      log_llog, NULL);
 	if (ret)
 		goto err_vtm;

--- a/tests/test_vt.c
+++ b/tests/test_vt.c
@@ -113,8 +113,8 @@ int main(int argc, char **argv)
 	if (ret)
 		goto err_exit;
 
-	ret = uterm_input_new(&input, eloop, "", "", "", "", "C", "", 0, 0,
-			      log_llog, NULL);
+	ret = uterm_input_new(&input, eloop, "", "", "", "", "C", "", "", 0, 0,
+			      0, log_llog, NULL);
 	if (ret)
 		goto err_vtm;
 


### PR DESCRIPTION
@snakeroot linked to their implementation in #23. I had independently written a (worse) patch as well. I've taken inspiration from both @snakeroot's and my own implementation for this PR. The main functional difference between their version and this one is that this PR does not require a command-line option to enable Compose support.

Only the first and fourth commits are actually needed. The second commit adds a new launcher to also query the locale information from systemd-localed. The third commit allows the user to specify a Compose file explicitly, but I don't know if that's really useful?