### PR TITLE
Fix undefined behavior

### DIFF
--- a/src/uterm_input_internal.h
+++ b/src/uterm_input_internal.h
@@ -84,7 +84,7 @@ struct uterm_input {
 
 static inline bool input_bit_is_set(const unsigned long *array, int bit)
 {
-	return !!(array[bit / LONG_BIT] & (1LL << (bit % LONG_BIT)));
+	return !!(array[bit / LONG_BIT] & (1UL << (bit % LONG_BIT)));
 }
 
 int uxkb_desc_init(struct uterm_input *input,


### PR DESCRIPTION
When `long long` and `unsigned long` are both 64 bits, `1LL << 63` is undefined behavior, because it overflows. Use an `unsigned long` literal instead, because it has no overflow and thus no undefined behavior.