### PR TITLE
Add unifont binary source and clangd compile config to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ aclocal.m4
 autom4te.cache/
 build-aux/
 build/
+compile_commands.json
 config.h
 config.h.in
 config.h.in~
@@ -30,6 +31,7 @@ stamp-*
 genunifont
 src/shl_githead.c
 src/font_unifont_data.bin
+src/font_unifont_data.bin.c
 docs/reference/*.txt
 docs/reference/*.bak
 docs/reference/kmscon.????*


### PR DESCRIPTION
Just some gitignore changes... the unifont binary source one is probably an oversight. I added the compile options to enable clangd language server integration, too.