### PR TITLE
Make code sent by backspace key configurable

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -47,7 +47,7 @@ systemdsystemunitdir = systemd_deps.get_variable('systemdsystemunitdir', default
 fs = import('fs')
 
 xkbcommon_deps = dependency('xkbcommon', version: '>=0.5.0')
-libtsm_deps = dependency('libtsm', version: '>=4.0.0')
+libtsm_deps = dependency('libtsm', version: '>=4.1.0')
 libudev_deps = dependency('libudev', version: '>=172')
 dl_deps = dependency('dl')
 threads_deps = dependency('threads')
@@ -118,6 +118,7 @@ endforeach
 config.set('BUILD_ENABLE_DEBUG', get_option('extra_debug'))
 config.set_quoted('BUILD_MODULE_DIR', prefix / moduledir)
 config.set_quoted('BUILD_CONFIG_DIR', prefix / sysconfdir)
+config.set10('BUILD_BACKSPACE_SENDS_DELETE', get_option('backspace_sends_delete'))
 
 # Make all files include "config.h" by default. This shouldn't cause any
 # problems and we cannot forget to include it anymore.
@@ -157,6 +158,7 @@ summary({
   'extra_debug': get_option('extra_debug'),
   'tests': get_option('tests'),
   'docs': enable_docs,
+  'backspace_sends_delete': get_option('backspace_sends_delete'),
 }, section: 'Miscellaneous')
 
 #

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -36,3 +36,7 @@ option('session_dummy', type: 'feature', value: 'auto',
   description: 'dummy session')
 option('session_terminal', type: 'feature', value: 'auto',
   description: 'terminal session')
+
+# terminal options
+option('backspace_sends_delete', type: 'boolean', value: 'false',
+  description: 'backspace sends ASCII delete (0177) instead of ASCII backspace (010)')

--- a/src/kmscon_terminal.c
+++ b/src/kmscon_terminal.c
@@ -624,6 +624,9 @@ int kmscon_terminal_register(struct kmscon_session **out,
 	if (ret)
 		goto err_con;
 
+	tsm_vte_set_backspace_sends_delete(term->vte,
+					   BUILD_BACKSPACE_SENDS_DELETE);
+
 	ret = tsm_vte_set_palette(term->vte, term->conf->palette);
 	if (ret)
 		goto err_vte;

--- a/src/pty.c
+++ b/src/pty.c
@@ -340,8 +340,13 @@ static void setup_child(int master, struct winsize *ws)
 		goto err_out;
 	}
 
-	/* erase character should be normal backspace */
-	attr.c_cc[VERASE] = 010;
+	if (BUILD_BACKSPACE_SENDS_DELETE) {
+		/* erase character should be delete */
+		attr.c_cc[VERASE] = 0177;
+	} else {
+		/* erase character should be normal backspace */
+		attr.c_cc[VERASE] = 010;
+	}
 
 	/* set changed terminal attributes */
 	if (tcsetattr(slave, TCSANOW, &attr) < 0) {


### PR DESCRIPTION
Keep the default code as ASCII backspace, but allow setting the code to
ASCII delete. This is the code used by the Linux console and most modern
terminal emulators by default.

For Debian I would like to set the default to delete, but if you prefer not to do that here, I will add a downstream patch.

This depends on Aetf/libtsm#23.