### PR TITLE
Use current KMS videomode by default and add an option to control this.

### DIFF
--- a/docs/man/kmscon.1.xml.in
+++ b/docs/man/kmscon.1.xml.in
@@ -482,6 +482,13 @@
                 only be used to debug render engines. (default: off)</para>
         </listitem>
       </varlistentry>
+
+      <varlistentry>
+        <term><option>--use-original-mode</option></term>
+        <listitem>
+          <para>Use original KMS mode to prevent modesetting. (default: on)</para>
+        </listitem>
+      </varlistentry>
     </variablelist>
 
     <para>Font Options:</para>

--- a/src/kmscon_conf.c
+++ b/src/kmscon_conf.c
@@ -142,6 +142,7 @@ static void print_help()
 		"\t    --gpus={all,aux,primary}[all]   GPU selection mode\n"
 		"\t    --render-engine <eng>   [-]     Console renderer\n"
 		"\t    --render-timing         [off]   Print renderer timing information\n"
+		"\t    --use-original-mode     [on]    Use original KMS video mode\n"
 		"\n"
 		"Font Options:\n"
 		"\t    --font-engine <engine>  [pango]\n"
@@ -734,6 +735,7 @@ int kmscon_conf_new(struct conf_ctx **out)
 		CONF_OPTION_BOOL(0, "hwaccel", &conf->hwaccel, false),
 		CONF_OPTION(0, 0, "gpus", &conf_gpus, NULL, NULL, NULL, &conf->gpus, KMSCON_GPU_ALL),
 		CONF_OPTION_STRING(0, "render-engine", &conf->render_engine, NULL),
+		CONF_OPTION_BOOL(0, "use-original-mode", &conf->use_original_mode, true),
 
 		/* Font Options */
 		CONF_OPTION_STRING(0, "font-engine", &conf->font_engine, "pango"),

--- a/src/kmscon_conf.h
+++ b/src/kmscon_conf.h
@@ -145,6 +145,8 @@ struct kmscon_conf_t {
 	unsigned int gpus;
 	/* render engine */
 	char *render_engine;
+	/* use current KMS video mode to avoid modesetting */
+	bool use_original_mode;
 
 	/* Font Options */
 	/* font engine */

--- a/src/kmscon_seat.c
+++ b/src/kmscon_seat.c
@@ -154,11 +154,17 @@ static void activate_display(struct kmscon_display *d)
 	if (d->activated || !d->seat->awake || !d->seat->foreground)
 		return;
 
-	/* TODO: We always use the default mode for new displays but we should
-	 * rather allow the user to specify different modes in the configuration
-	 * files. */
+	/* TODO: We use the current KMS mode for new displays to avoid modesetting
+	 * unless the user specifies not to, in which case we use the default mode,
+	 * but we should also allow the user to specify different modes in the
+	 * configuration files. */
 	if (uterm_display_get_state(d->disp) == UTERM_DISPLAY_INACTIVE) {
-		ret = uterm_display_activate(d->disp, NULL);
+		if (seat->conf->use_original_mode)
+			ret = uterm_display_activate(d->disp,
+						     uterm_display_get_original(d->disp));
+		else
+			ret = uterm_display_activate(d->disp, NULL);
+
 		if (ret)
 			return;
 

--- a/src/uterm_drm_shared.c
+++ b/src/uterm_drm_shared.c
@@ -599,6 +599,10 @@ static void bind_display(struct uterm_video *video, drmModeRes *res,
 		return;
 	ddrm = disp->data;
 
+	drmModeEncoder *enc = drmModeGetEncoder(vdrm->fd, conn->encoder_id);
+	drmModeCrtc *current_crtc = drmModeGetCrtc(vdrm->fd, enc->crtc_id);
+	drmModeFreeEncoder(enc);
+
 	for (i = 0; i < conn->count_modes; ++i) {
 		ret = mode_new(&mode, &uterm_drm_mode_ops);
 		if (ret)
@@ -615,6 +619,10 @@ static void bind_display(struct uterm_video *video, drmModeRes *res,
 		/* TODO: more sophisticated default-mode selection */
 		if (!disp->default_mode)
 			disp->default_mode = mode;
+
+		/* Save the original KMS mode for later use */
+		if (memcmp(&conn->modes[i], &current_crtc->mode, sizeof(conn->modes[i])) == 0)
+		 	disp->original_mode = mode;
 
 		uterm_mode_unref(mode);
 	}

--- a/src/uterm_video.c
+++ b/src/uterm_video.c
@@ -383,6 +383,15 @@ struct uterm_mode *uterm_display_get_default(struct uterm_display *disp)
 }
 
 SHL_EXPORT
+struct uterm_mode *uterm_display_get_original(struct uterm_display *disp)
+{
+	if (!disp)
+		return NULL;
+
+	return disp->original_mode;
+}
+
+SHL_EXPORT
 int uterm_display_get_state(struct uterm_display *disp)
 {
 	if (!disp)

--- a/src/uterm_video.h
+++ b/src/uterm_video.h
@@ -159,6 +159,7 @@ void uterm_display_unregister_cb(struct uterm_display *disp,
 struct uterm_mode *uterm_display_get_modes(struct uterm_display *disp);
 struct uterm_mode *uterm_display_get_current(struct uterm_display *disp);
 struct uterm_mode *uterm_display_get_default(struct uterm_display *disp);
+struct uterm_mode *uterm_display_get_original(struct uterm_display *disp);
 
 int uterm_display_get_state(struct uterm_display *disp);
 int uterm_display_activate(struct uterm_display *disp, struct uterm_mode *mode);

--- a/src/uterm_video_internal.h
+++ b/src/uterm_video_internal.h
@@ -119,6 +119,7 @@ struct uterm_display {
 	struct shl_dlist modes;
 	struct uterm_mode *default_mode;
 	struct uterm_mode *current_mode;
+	struct uterm_mode *original_mode;
 	int dpms;
 
 	bool vblank_scheduled;


### PR DESCRIPTION
This is meant to prevent modesetting when the KMS video mode doesn't match the default display mode.
Doing a full modesetting causes a display blanking on (all?) modern displays and it's something that should be avoided.  