### PR TITLE
Add elogind support

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -65,7 +65,12 @@ python = find_program('python3')
 require_glesv2 = get_option('video_drm3d').enabled() or get_option('renderer_gltex').enabled()
 require_libdrm = get_option('video_drm2d').enabled() or get_option('video_drm3d').enabled()
 
-libsystemd_deps = dependency('libsystemd', disabler: true, required: get_option('multi_seat'))
+if get_option('elogind').enabled()
+	multi_seat_dep = 'libelogind'
+else
+	multi_seat_dep = 'libsystemd'
+endif
+libsystemd_deps = dependency(multi_seat_dep, disabler: true, required: get_option('multi_seat'))
 libdrm_deps = dependency('libdrm', disabler: true, required: require_libdrm)
 gbm_deps = dependency('gbm', disabler: true, required: get_option('video_drm3d'))
 egl_deps = dependency('egl', disabler: true, required: get_option('video_drm3d'))

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -7,7 +7,9 @@ option('docs', type: 'feature', value: 'auto',
 
 # multi-seat
 option('multi_seat', type: 'feature', value: 'auto',
-  description: 'Multi-seat support with systemd')
+  description: 'Multi-seat support with systemd or elogind')
+option('elogind', type: 'feature', value: 'disabled',
+  description: 'Prefer elogind over systemd')
 
 # video backends
 option('video_fbdev', type: 'feature', value: 'auto',


### PR DESCRIPTION
This is an attempt to add [elogind](https://github.com/elogind/elogind) support. It should be API compatible to systemd's logind and thus only requires some changes in the meson build system.

Signed-off-by: Lars Wendler <polynomial-c@gmx.de>