### PR TITLE
Add missing libtsm_deps to pixman renderer

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -219,7 +219,7 @@ if enable_renderer_pixman
       'kmscon_mod_pixman.c',
     ],
     name_prefix: '',
-    dependencies: [pixman_deps, shl_deps],
+    dependencies: [libtsm_deps, pixman_deps, shl_deps],
     install: true,
     install_dir: moduledir,
   )


### PR DESCRIPTION
I had installed libtsm-4.0.2 to a non-standard directory and got an error while compiling - since libtsm_deps wasn't listed as a dependency, the required CFLAGS weren't being used while compiling.