### PR TITLE
Add arguments to set the desired resolution.

### DIFF
--- a/docs/man/kmscon.1.xml.in
+++ b/docs/man/kmscon.1.xml.in
@@ -501,24 +501,22 @@
         <listitem>
           <para>Use original KMS mode to prevent modesetting. (default: on)</para>
 
-          <para>This option is incompatible with --desired-width and
-                --desired-height.</para>
+          <para>This option is incompatible with --mode.</para>
         </listitem>
       </varlistentry>
 
       <varlistentry>
-        <term><option>--desired-width {pixels}</option></term>
-        <term><option>--desired-height {pixels}</option></term>
+        <term><option>--mode {width}x{height}</option></term>
         <listitem>
-          <para>Set the desired width and height of the output. The given width
+          <para>Set the desired output mode. The given width
           and height must match a supported more exactly for this option to have
           any effect; if there is no supported mode that matches exactly, or if there is
           an error when using the desired mode, then the default mode (first valid mode
           found) will be used.</para>
 
-          <para>--use-original-mode must be disabled in order to use these options.</para>
+          <para>--use-original-mode must be disabled in order to use this option.</para>
 
-          <para>Modesetting is only supported in DRM mode, so these options do
+          <para>Modesetting is only supported in DRM mode, so this option does
           nothing with fbdev. However, fbset can still be used to externally set
           the mode when fbdev is in use.</para>
 

--- a/docs/man/kmscon.1.xml.in
+++ b/docs/man/kmscon.1.xml.in
@@ -500,6 +500,32 @@
         <term><option>--use-original-mode</option></term>
         <listitem>
           <para>Use original KMS mode to prevent modesetting. (default: on)</para>
+
+          <para>This option is incompatible with --desired-width and
+                --desired-height.</para>
+        </listitem>
+      </varlistentry>
+
+      <varlistentry>
+        <term><option>--desired-width {pixels}</option></term>
+        <term><option>--desired-height {pixels}</option></term>
+        <listitem>
+          <para>Set the desired width and height of the output. The given width
+          and height must match a supported more exactly for this option to have
+          any effect; if there is no supported mode that matches exactly, or if there is
+          an error when using the desired mode, then the default mode (first valid mode
+          found) will be used.</para>
+
+          <para>--use-original-mode must be disabled in order to use these options.</para>
+
+          <para>Modesetting is only supported in DRM mode, so these options do
+          nothing with fbdev. However, fbset can still be used to externally set
+          the mode when fbdev is in use.</para>
+
+          <para>Other system components may need configuration in order to use the desired
+          mode effectively. For example, the `video={width}x{height}` kernel parameter may
+          be required in order to ensure that there is enough memory to store the
+          framebuffers for a large resolution.</para>
         </listitem>
       </varlistentry>
     </variablelist>

--- a/src/kmscon_conf.c
+++ b/src/kmscon_conf.c
@@ -143,13 +143,12 @@ static void print_help()
 		"\t    --render-engine <eng>     [-]     Console renderer\n"
 		"\t    --render-timing           [off]   Print renderer timing information\n"
 		"\t    --use-original-mode     [on]    Use original KMS video mode\n"
-		"\t    --desired-width <pixels>  [0]\n"
-		"\t    --desired-height <pixels> [0]     Set the desired width/height of\n"
-		"\t                                      the output. If the desired mode\n"
-		"\t                                      is not available or encounters an\n"
-		"\t                                      error, a default mode will be\n"
-		"\t                                      used. See the man page for\n"
-		"\t                                      additional details.\n"
+		"\t    --mode <width>x<height>   [0x0]  Set the desired mode for the\n"
+		"\t                                     output. If the specified mode is\n"
+		"\t                                     not available or encounterns an\n"
+		"\t                                     error, a default mode will be used.\n"
+		"\t                                     This option is incompatible with\n"
+		"\t                                     --use-original-mode.\n"
 		"\n"
 		"Font Options:\n"
 		"\t    --font-engine <engine>  [pango]\n"
@@ -737,8 +736,7 @@ int kmscon_conf_new(struct conf_ctx **out)
 		CONF_OPTION(0, 0, "gpus", &conf_gpus, NULL, NULL, NULL, &conf->gpus, KMSCON_GPU_ALL),
 		CONF_OPTION_STRING(0, "render-engine", &conf->render_engine, NULL),
 		CONF_OPTION_BOOL(0, "use-original-mode", &conf->use_original_mode, true),
-		CONF_OPTION_UINT(0, "desired-width", &conf->desired_width, 0),
-		CONF_OPTION_UINT(0, "desired-height", &conf->desired_height, 0),
+		CONF_OPTION_STRING(0, "mode", &conf->mode, NULL),
 
 		/* Font Options */
 		CONF_OPTION_STRING(0, "font-engine", &conf->font_engine, "pango"),
@@ -812,8 +810,8 @@ int kmscon_conf_load_main(struct conf_ctx *ctx, int argc, char **argv)
 	 * kmscon should use a specific mode. If both are in effect then the correct
 	 * mode is ambiguous. Error out and tell the user.
 	 */
-	if (conf->use_original_mode && (conf->desired_width != 0 || conf->desired_height !=0)) {
-		fprintf(stderr, "Cannot use desired-width or desired-height if use-original-mode is enabled. Try --no-use-original-mode.\n");
+	if (conf->use_original_mode && conf->mode != NULL) {
+		fprintf(stderr, "Cannot use --mode if --use-original-mode is enabled. Try --no-use-original-mode.\n");
 		return -EINVAL;
 	}
 

--- a/src/kmscon_conf.c
+++ b/src/kmscon_conf.c
@@ -136,13 +136,20 @@ static void print_help()
 		"\t                                  Create a new terminal session\n"
 		"\n"
 		"Video Options:\n"
-		"\t    --drm                   [on]    Use DRM if available\n"
-		"\t    --hwaccel               [off]   Use 3D hardware acceleration if\n"
-		"\t                                    available\n"
-		"\t    --gpus={all,aux,primary}[all]   GPU selection mode\n"
-		"\t    --render-engine <eng>   [-]     Console renderer\n"
-		"\t    --render-timing         [off]   Print renderer timing information\n"
+		"\t    --drm                     [on]    Use DRM if available\n"
+		"\t    --hwaccel                 [off]   Use 3D hardware-acceleration if\n"
+		"\t                                      available\n"
+		"\t    --gpus={all,aux,primary}  [all]   GPU selection mode\n"
+		"\t    --render-engine <eng>     [-]     Console renderer\n"
+		"\t    --render-timing           [off]   Print renderer timing information\n"
 		"\t    --use-original-mode     [on]    Use original KMS video mode\n"
+		"\t    --desired-width <pixels>  [0]\n"
+		"\t    --desired-height <pixels> [0]     Set the desired width/height of\n"
+		"\t                                      the output. If the desired mode\n"
+		"\t                                      is not available or encounters an\n"
+		"\t                                      error, a default mode will be\n"
+		"\t                                      used. See the man page for\n"
+		"\t                                      additional details.\n"
 		"\n"
 		"Font Options:\n"
 		"\t    --font-engine <engine>  [pango]\n"
@@ -730,6 +737,8 @@ int kmscon_conf_new(struct conf_ctx **out)
 		CONF_OPTION(0, 0, "gpus", &conf_gpus, NULL, NULL, NULL, &conf->gpus, KMSCON_GPU_ALL),
 		CONF_OPTION_STRING(0, "render-engine", &conf->render_engine, NULL),
 		CONF_OPTION_BOOL(0, "use-original-mode", &conf->use_original_mode, true),
+		CONF_OPTION_UINT(0, "desired-width", &conf->desired_width, 0),
+		CONF_OPTION_UINT(0, "desired-height", &conf->desired_height, 0),
 
 		/* Font Options */
 		CONF_OPTION_STRING(0, "font-engine", &conf->font_engine, "pango"),

--- a/src/kmscon_conf.c
+++ b/src/kmscon_conf.c
@@ -808,6 +808,15 @@ int kmscon_conf_load_main(struct conf_ctx *ctx, int argc, char **argv)
 	if (conf->exit)
 		return 0;
 
+	/* Both use-original mode and desired-width/desired-height specify that
+	 * kmscon should use a specific mode. If both are in effect then the correct
+	 * mode is ambiguous. Error out and tell the user.
+	 */
+	if (conf->use_original_mode && (conf->desired_width != 0 || conf->desired_height !=0)) {
+		fprintf(stderr, "Cannot use desired-width or desired-height if use-original-mode is enabled. Try --no-use-original-mode.\n");
+		return -EINVAL;
+	}
+
 	if (!conf->debug && !conf->verbose && conf->silent)
 		log_set_config(&LOG_CONFIG_WARNING(0, 0, 0, 0));
 	else

--- a/src/kmscon_conf.h
+++ b/src/kmscon_conf.h
@@ -147,6 +147,9 @@ struct kmscon_conf_t {
 	char *render_engine;
 	/* use current KMS video mode to avoid modesetting */
 	bool use_original_mode;
+	/* screen resolution */
+	unsigned int desired_width;
+	unsigned int desired_height;
 
 	/* Font Options */
 	/* font engine */

--- a/src/kmscon_conf.h
+++ b/src/kmscon_conf.h
@@ -148,8 +148,7 @@ struct kmscon_conf_t {
 	/* use current KMS video mode to avoid modesetting */
 	bool use_original_mode;
 	/* screen resolution */
-	unsigned int desired_width;
-	unsigned int desired_height;
+	char *mode;
 
 	/* Font Options */
 	/* font engine */

--- a/src/kmscon_main.c
+++ b/src/kmscon_main.c
@@ -367,13 +367,16 @@ static int app_seat_add_video(struct app_seat *seat,
 		mode = UTERM_VIDEO_FBDEV;
 	}
 
-	ret = uterm_video_new(&vid->video, seat->app->eloop, node, mode);
+	ret = uterm_video_new(&vid->video, seat->app->eloop, node, mode,
+			      seat->conf->desired_width, seat->conf->desired_height);
 	if (ret) {
 		if (mode == UTERM_VIDEO_DRM3D) {
 			log_info("cannot create drm3d device %s on seat %s (%d); trying drm2d mode",
 				 vid->node, seat->name, ret);
 			ret = uterm_video_new(&vid->video, seat->app->eloop,
-					      node, UTERM_VIDEO_DRM2D);
+					      node, UTERM_VIDEO_DRM2D,
+					      seat->conf->desired_width,
+					      seat->conf->desired_height);
 			if (ret)
 				goto err_node;
 		} else {

--- a/src/kmscon_main.c
+++ b/src/kmscon_main.c
@@ -367,16 +367,24 @@ static int app_seat_add_video(struct app_seat *seat,
 		mode = UTERM_VIDEO_FBDEV;
 	}
 
+	unsigned int desired_width = 0;
+	unsigned int desired_height = 0;
+	if (seat->conf->mode != NULL) {
+		int items_parsed = sscanf(seat->conf->mode, "%ux%u", &desired_width, &desired_height);
+		if (items_parsed != 2) {
+			log_warning("The argument to --mode is not in the format <width>x<height>. Ignoring");
+			desired_width = 0;
+			desired_height = 0;
+		}
+	}
 	ret = uterm_video_new(&vid->video, seat->app->eloop, node, mode,
-			      seat->conf->desired_width, seat->conf->desired_height);
+	                      desired_width, desired_height);
 	if (ret) {
 		if (mode == UTERM_VIDEO_DRM3D) {
 			log_info("cannot create drm3d device %s on seat %s (%d); trying drm2d mode",
 				 vid->node, seat->name, ret);
 			ret = uterm_video_new(&vid->video, seat->app->eloop,
-					      node, UTERM_VIDEO_DRM2D,
-					      seat->conf->desired_width,
-					      seat->conf->desired_height);
+					      node, UTERM_VIDEO_DRM2D, desired_width, desired_height);
 			if (ret)
 				goto err_node;
 		} else {

--- a/src/kmscon_seat.c
+++ b/src/kmscon_seat.c
@@ -165,6 +165,8 @@ static void activate_display(struct kmscon_display *d)
 		else
 			ret = uterm_display_activate(d->disp, NULL);
 
+		if (ret == -EAGAIN)
+			ret = uterm_display_activate(d->disp, NULL);
 		if (ret)
 			return;
 

--- a/src/kmscon_terminal.c
+++ b/src/kmscon_terminal.c
@@ -114,6 +114,8 @@ static void do_clear_margins(struct screen *scr)
 				   sw, dh);
 }
 
+static int font_set(struct kmscon_terminal *term);
+
 static void do_redraw_screen(struct screen *scr)
 {
 	int ret;
@@ -129,6 +131,14 @@ static void do_redraw_screen(struct screen *scr)
 	kmscon_text_render(scr->txt);
 
 	ret = uterm_display_swap(scr->disp, false);
+
+	if (ret == -EAGAIN) {
+		uterm_display_deactivate(scr->disp);
+		uterm_display_activate(scr->disp, NULL);
+		font_set(scr->term);
+		ret = uterm_display_swap(scr->disp, false);
+	}
+
 	if (ret) {
 		log_warning("cannot swap display %p", scr->disp);
 		return;

--- a/src/kmscon_terminal.c
+++ b/src/kmscon_terminal.c
@@ -134,9 +134,11 @@ static void do_redraw_screen(struct screen *scr)
 
 	if (ret == -EAGAIN) {
 		uterm_display_deactivate(scr->disp);
-		uterm_display_activate(scr->disp, NULL);
-		font_set(scr->term);
-		ret = uterm_display_swap(scr->disp, false);
+		ret = uterm_display_activate(scr->disp, NULL);
+		if (!ret)
+			ret = font_set(scr->term);
+		if (!ret)
+			ret = uterm_display_swap(scr->disp, false);
 	}
 
 	if (ret) {

--- a/src/uterm_drm2d_video.c
+++ b/src/uterm_drm2d_video.c
@@ -190,7 +190,12 @@ static int display_activate(struct uterm_display *disp, struct uterm_mode *mode)
 	ret = drmModeSetCrtc(vdrm->fd, ddrm->crtc_id,
 			     d2d->rb[0].fb, 0, 0, &ddrm->conn_id, 1,
 			     minfo);
-	if (ret) {
+
+	if (ret && mode == disp->desired_mode && mode != disp->default_mode) {
+		mode = disp->desired_mode = disp->default_mode;
+		ret = -EAGAIN;
+		goto err_fb;
+	} else if (ret) {
 		log_err("cannot set drm-crtc");
 		ret = -EFAULT;
 		goto err_fb;

--- a/src/uterm_drm3d_video.c
+++ b/src/uterm_drm3d_video.c
@@ -213,7 +213,11 @@ static int display_activate(struct uterm_display *disp,
 
 	ret = drmModeSetCrtc(vdrm->fd, ddrm->crtc_id, d3d->current->fb,
 			     0, 0, &ddrm->conn_id, 1, minfo);
-	if (ret) {
+	if (ret && mode == disp->desired_mode && mode != disp->default_mode) {
+		mode = disp->desired_mode = disp->default_mode;
+		ret = -EAGAIN;
+		goto err_bo;
+	} else if (ret) {
 		log_err("cannot set drm-crtc");
 		ret = -EFAULT;
 		goto err_bo;

--- a/src/uterm_drm_shared.c
+++ b/src/uterm_drm_shared.c
@@ -362,6 +362,11 @@ int uterm_drm_display_swap(struct uterm_display *disp, uint32_t fb,
 		ret = drmModePageFlip(vdrm->fd, ddrm->crtc_id, fb,
 				      DRM_MODE_PAGE_FLIP_EVENT, disp);
 		if (ret) {
+			if (disp->desired_mode != disp->default_mode) {
+				disp->desired_mode = disp->default_mode;
+				log_debug("Unable to page-flip desired mode! Switching to default mode.");
+				return -EAGAIN;
+			}
 			log_error("cannot page-flip on DRM-CRTC (%d): %m",
 				  errno);
 			return -EFAULT;
@@ -634,10 +639,28 @@ static void bind_display(struct uterm_video *video, drmModeRes *res,
 		if (current_crtc && memcmp(&conn->modes[i], &current_crtc->mode, sizeof(conn->modes[i])) == 0)
 		 	disp->original_mode = mode;
 
+		if (video->desired_width != 0 &&
+		    video->desired_height != 0 &&
+		    mode->ops->get_width(mode) == video->desired_width &&
+		    mode->ops->get_height(mode) == video->desired_height)
+			disp->desired_mode = mode;
+
 		uterm_mode_unref(mode);
 	}
 	if (current_crtc)
 		drmModeFreeCrtc(current_crtc);
+
+	if (!disp->desired_mode) {
+		disp->desired_mode = disp->default_mode;
+	}
+
+	log_debug("Default mode %dx%d",
+		  disp->default_mode->ops->get_width(disp->default_mode),
+		  disp->default_mode->ops->get_height(disp->default_mode));
+
+	log_debug("Desired mode %dx%d",
+		  disp->desired_mode->ops->get_width(disp->desired_mode),
+		  disp->desired_mode->ops->get_height(disp->desired_mode));
 
 	if (shl_dlist_empty(&disp->modes)) {
 		log_warn("no valid mode for display found");

--- a/src/uterm_video.c
+++ b/src/uterm_video.c
@@ -407,7 +407,7 @@ int uterm_display_activate(struct uterm_display *disp, struct uterm_mode *mode)
 		return -EINVAL;
 
 	if (!mode)
-		mode = disp->default_mode;
+		mode = disp->desired_mode;
 
 	return VIDEO_CALL(disp->ops->activate, 0, disp, mode);
 }
@@ -541,7 +541,8 @@ int uterm_display_fake_blendv(struct uterm_display *disp,
 
 SHL_EXPORT
 int uterm_video_new(struct uterm_video **out, struct ev_eloop *eloop,
-		    const char *node, const struct uterm_video_module *mod)
+		    const char *node, const struct uterm_video_module *mod,
+		    unsigned int desired_width, unsigned int desired_height)
 {
 	struct uterm_video *video;
 	int ret;
@@ -568,6 +569,9 @@ int uterm_video_new(struct uterm_video **out, struct ev_eloop *eloop,
 	ret = VIDEO_CALL(video->ops->init, 0, video, node);
 	if (ret)
 		goto err_hook;
+
+	video->desired_width = desired_width;
+	video->desired_height = desired_height;
 
 	ev_eloop_ref(video->eloop);
 	log_info("new device %p", video);

--- a/src/uterm_video.h
+++ b/src/uterm_video.h
@@ -192,7 +192,8 @@ int uterm_display_fake_blendv(struct uterm_display *disp,
 /* video interface */
 
 int uterm_video_new(struct uterm_video **out, struct ev_eloop *eloop,
-		    const char *node, const struct uterm_video_module *mod);
+		    const char *node, const struct uterm_video_module *mod,
+		    unsigned int desired_width, unsigned int desired_height);
 void uterm_video_ref(struct uterm_video *video);
 void uterm_video_unref(struct uterm_video *video);
 

--- a/src/uterm_video_internal.h
+++ b/src/uterm_video_internal.h
@@ -118,6 +118,7 @@ struct uterm_display {
 	struct shl_hook *hook;
 	struct shl_dlist modes;
 	struct uterm_mode *default_mode;
+	struct uterm_mode *desired_mode;
 	struct uterm_mode *current_mode;
 	struct uterm_mode *original_mode;
 	int dpms;
@@ -159,6 +160,9 @@ struct uterm_video {
 
 	struct shl_dlist displays;
 	struct shl_hook *hook;
+
+	unsigned int desired_width;
+	unsigned int desired_height;
 
 	const struct uterm_video_module *mod;
 	const struct video_ops *ops;

--- a/tests/test_output.c
+++ b/tests/test_output.c
@@ -58,6 +58,8 @@ struct {
 	bool fbdev;
 	bool test;
 	char *dev;
+	unsigned int desired_width;
+	unsigned int desired_height;
 } output_conf;
 
 static int blit_outputs(struct uterm_video *video)
@@ -187,6 +189,8 @@ struct conf_option options[] = {
 	CONF_OPTION_BOOL(0, "fbdev", &output_conf.fbdev, false),
 	CONF_OPTION_BOOL(0, "test", &output_conf.test, false),
 	CONF_OPTION_STRING(0, "dev",  &output_conf.dev, NULL),
+	CONF_OPTION_UINT(0, "desired-width", &output_conf.desired_width, 0),
+	CONF_OPTION_UINT(0, "desired-height", &output_conf.desired_height, 0),
 };
 
 int main(int argc, char **argv)
@@ -215,12 +219,16 @@ int main(int argc, char **argv)
 
 	log_notice("Creating video object using %s...", node);
 
-	ret = uterm_video_new(&video, eloop, node, mode);
+	ret = uterm_video_new(&video, eloop, node, mode,
+			      output_conf.desired_width,
+			      output_conf.desired_height);
 	if (ret) {
 		if (mode == UTERM_VIDEO_DRM3D) {
 			log_notice("cannot create drm device; trying drm2d mode");
 			ret = uterm_video_new(&video, eloop, node,
-					      UTERM_VIDEO_DRM2D);
+					      UTERM_VIDEO_DRM2D,
+					      output_conf.desired_width,
+					      output_conf.desired_height);
 			if (ret)
 				goto err_exit;
 		} else {


### PR DESCRIPTION
Hi @Aetf! I prepared this change for personal use because I wanted a larger resolution in my VM, and wanted to offer it to you because it seems generally useful (and as noted below, other users have had this problem). I saw your README stating that this is a personal fork just because the upstream repository has not been updated in a long time, so if you don't want to deal with extra random patches being added that makes perfect sense, but since you have a repository that  has been updated more recently I thought it made sense to offer it to you before going elsewhere. Let me know what you think! =)

**Problem Being Solved**

It is currently not possible to set the resolution that kmscon displays at. This was a pain point for me, using kmscon instead of agetty in a VM, because the mode it selected used less than half of my screen space. The unmaintained repository has [an issue open about this](https://github.com/dvdhrm/kmscon/issues/124), so it is a pain point for others too.

**Solution**

This commit adds 2 new arguments to the command-line interface, which allow the user to specify their desired resolution. This only works in DRM mode, because kmscon does not support modesetting in fbdev:

https://github.com/Aetf/kmscon/blob/662884a4c8b7549684b0b81924d0660ffe2c472c/src/uterm_fbdev_video.c#L149

Additionally, it only works if there is a mode which exactly matches the resolution specified. If no mode matches, or if fbdev is used, then the current behavior is preserved.

There are one root changes which facilitate this, another significant change which enables it, and some minor changes required for compatibility. The root change is that [the loop that selects a mode now checks if any mode matches the desired resolution, and sets it as the default if so]. This loop does not have direct access to the configuration data, so the desired width and height are stored in the uterm_video struct - this seemed like the least intrusive way to transfer the data, but I could update the commit to pass these values as separate arguments if desired. The other changes are related to making sure that the struct is fully initialized and updating the help output/man page.

**Risks**

These arguments can break kmscon if other system components are not configured correctly. In particular, on my VM kmscon initially output a blank screen due to an out of memory error. I had to pass video=1920x1080 as a kernel argument in order to resolve this issue. Restarting kmscon without specifying the resolution was sufficient to restore functionality.

I do not consider this commit to cause any regression because the behavior of the program is unchanged when the new arguments are not used.

**Future Work**

There are 2 items which I think are beyond the scope of this commit, but I will note as things I would like to add in the future (time allowing, a lot of things are up in the air right now for me).

First, using the mode that kmscon would previously select as a fallback mode when loading the desired resolution fails. In the case I encountered, it is easy to detect the fail state because the ioctl's that underlie either uterm_display_activate or uterm_display_swap return an out of memory error code. I tried adding simple logic to both of these functions to load the fallback mode, but this resulted in a screen that only rendered one line of output even though the correct mode was listed in the log output (and kmscon was clearly trying to print below the first line because the terminal didn't scroll after running commands, but the output was not rendered). As the fallback system is not needed to avoid a regression, I think it is fine for this to be considered out of scope for this commit.

Second, the test file does not allow for modesetting. I'm not sure what the scope of work required is here, since setting the mode after kmscon has initialized a display did not go well when I tried to do it for the fallback mode. I am less comfortable with having an untested feature than a less robust feature, if you happen to know what's needed here I'd love to hear about it.

Thank you for your consideration!

\- Skyler