### PR TITLE
Fix build warnings and update build readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Released tarballs can be found at: https://github.com/Aetf/kmscon/releases
 
 To compile the kmscon binary, run the standard meson commands:
 ```bash
-meson builddir/
+meson setup builddir/
 ````
 
 By default this will install into `/usr/local`, you can change your prefix with `--prefix=/usr`
@@ -44,7 +44,7 @@ By default this will install into `/usr/local`, you can change your prefix with 
 
 Then build and install. Note that this requires ninja.
 ```bash
-meson -C builddir/ install
+meson install -C builddir/
 ```
 
 The following meson options are available.

--- a/meson.build
+++ b/meson.build
@@ -7,7 +7,7 @@ project('kmscon', 'c',
   license: 'MIT',
   # meson 0.58: f-string
   # meson 0.62: dependency libdl
-  meson_version: '>=0.62.0',
+  meson_version: '>=1.1',
   default_options: [
     'warning_level=1',
     'werror=true',
@@ -129,7 +129,7 @@ config.set10('BUILD_BACKSPACE_SENDS_DELETE', get_option('backspace_sends_delete'
 # Make all files include "config.h" by default. This shouldn't cause any
 # problems and we cannot forget to include it anymore.
 config_h = configure_file(configuration: config, output: 'config.h')
-abs_config_h = meson.current_build_dir() / '@0@'.format(config_h)
+abs_config_h = meson.current_build_dir() / '@0@'.format('config.h')
 add_project_arguments('-include', abs_config_h, language: 'c')
 
 #

--- a/meson.options
+++ b/meson.options
@@ -40,5 +40,5 @@ option('session_terminal', type: 'feature', value: 'auto',
   description: 'terminal session')
 
 # terminal options
-option('backspace_sends_delete', type: 'boolean', value: 'false',
+option('backspace_sends_delete', type: 'boolean', value: false,
   description: 'backspace sends ASCII delete (0177) instead of ASCII backspace (010)')


### PR DESCRIPTION
Corrected the setup and build commands in the readme. Moved meson_options.txt to meson.options and set minimum meson version to 1.1. Fixed deprecated feature of using strings for boolean options and fixed a str.format warning.