### PR TITLE
Add login session tracking

### DIFF
--- a/src/kmscon_main.c
+++ b/src/kmscon_main.c
@@ -502,6 +502,11 @@ static void app_monitor_event(struct uterm_monitor *mon,
 		}
 		break;
 	case UTERM_MONITOR_UPDATE_SESSIONS:
+		seat = ev->seat_data;
+		if (!seat)
+			return;
+
+		kmscon_seat_update_sessions(seat->seat);
 		break;
 	}
 }

--- a/src/kmscon_main.c
+++ b/src/kmscon_main.c
@@ -501,6 +501,8 @@ static void app_monitor_event(struct uterm_monitor *mon,
 			break;
 		}
 		break;
+	case UTERM_MONITOR_UPDATE_SESSIONS:
+		break;
 	}
 }
 

--- a/src/kmscon_seat.c
+++ b/src/kmscon_seat.c
@@ -1077,6 +1077,9 @@ void kmscon_seat_update_sessions(struct kmscon_seat *seat)
 	shl_dlist_for_each_safe(iter, tmp, &seat->sessions) {
 		session = shl_dlist_entry(iter, struct kmscon_session,
 						list);
+		if (session == seat->dummy_sess)
+			continue;
+
 		kmscon_session_update_type(session);
 	}
 }

--- a/src/kmscon_seat.h
+++ b/src/kmscon_seat.h
@@ -104,6 +104,7 @@ int kmscon_seat_register_session(struct kmscon_seat *seat,
 				 struct kmscon_session **out,
 				 kmscon_session_cb_t cb,
 				 void *data);
+void kmscon_seat_update_sessions(struct kmscon_seat *seat);
 
 void kmscon_session_ref(struct kmscon_session *sess);
 void kmscon_session_unref(struct kmscon_session *sess);

--- a/src/kmscon_terminal.c
+++ b/src/kmscon_terminal.c
@@ -587,6 +587,27 @@ static void write_event(struct tsm_vte *vte, const char *u8, size_t len,
 	kmscon_pty_write(term->pty, u8, len);
 }
 
+int kmscon_terminal_get_child_pid(void *term)
+{
+	struct kmscon_terminal *t = term;
+
+	if (!t)
+		return -EINVAL;
+
+	return kmscon_pty_get_child(t->pty);
+}
+
+int kmscon_terminal_set_awake(void *data, bool awake)
+{
+	struct kmscon_terminal *term = data;
+
+	if (!term)
+		return -EINVAL;
+
+	term->awake = awake;
+	return 0;
+}
+
 int kmscon_terminal_register(struct kmscon_session **out,
 			     struct kmscon_seat *seat, unsigned int vtnr)
 {

--- a/src/kmscon_terminal.h
+++ b/src/kmscon_terminal.h
@@ -42,12 +42,24 @@
 int kmscon_terminal_register(struct kmscon_session **out,
 			     struct kmscon_seat *seat,
 			     unsigned int vtnr);
+int kmscon_terminal_get_child_pid(void *term);
+int kmscon_terminal_set_awake(void *term, bool awake);
 
 #else /* !BUILD_ENABLE_SESSION_TERMINAL */
 
 static inline int kmscon_terminal_register(struct kmscon_session **out,
 					   struct kmscon_seat *seat,
 					   unsigned int vtnr)
+{
+	return -EOPNOTSUPP;
+}
+
+int kmscon_terminal_get_child_pid(void *term)
+{
+	return -EOPNOTSUPP;
+}
+
+int kmscon_terminal_set_awake(void *term, bool awake)
 {
 	return -EOPNOTSUPP;
 }

--- a/src/pty.c
+++ b/src/pty.c
@@ -228,6 +228,14 @@ int kmscon_pty_get_fd(struct kmscon_pty *pty)
 	return ev_eloop_get_fd(pty->eloop);
 }
 
+int kmscon_pty_get_child(struct kmscon_pty *pty)
+{
+	if (!pty)
+		return -EINVAL;
+
+	return pty->child;
+}
+
 void kmscon_pty_dispatch(struct kmscon_pty *pty)
 {
 	if (!pty)

--- a/src/pty.h
+++ b/src/pty.h
@@ -62,6 +62,7 @@ int kmscon_pty_set_vtnr(struct kmscon_pty *pty, unsigned int vtnr);
 void kmscon_pty_set_env_reset(struct kmscon_pty *pty, bool do_reset);
 
 int kmscon_pty_get_fd(struct kmscon_pty *pty);
+int kmscon_pty_get_child(struct kmscon_pty *pty);
 void kmscon_pty_dispatch(struct kmscon_pty *pty);
 
 int kmscon_pty_open(struct kmscon_pty *pty, unsigned short width,

--- a/src/uterm_monitor.c
+++ b/src/uterm_monitor.c
@@ -166,7 +166,7 @@ static void monitor_sd_session_event(struct ev_fd *fd,
 			     void *data)
 {
 	struct uterm_monitor *mon = data;
-	
+
 	int ret = check_sd_event(mask);
 	if (ret)
 		return;
@@ -320,16 +320,14 @@ static void monitor_update_sessions(struct uterm_monitor *mon)
 	shl_dlist_for_each_safe(iter, tmp, &mon->seats) {
 		seat = shl_dlist_entry(iter, struct uterm_monitor_seat,
 						list);
-		
+
 		struct uterm_monitor_event ev;
-	
+
 		memset(&ev, 0, sizeof(ev));
 
 		ev.type = UTERM_MONITOR_UPDATE_SESSIONS;
-		ev.seat = seat;
-		ev.seat_name = seat->name;
 		ev.seat_data = seat->data;
-	
+
 		seat->mon->cb(seat->mon, &ev, seat->mon->data);
 	}
 }

--- a/src/uterm_monitor.h
+++ b/src/uterm_monitor.h
@@ -47,6 +47,7 @@ enum uterm_monitor_event_type {
 	UTERM_MONITOR_NEW_DEV,
 	UTERM_MONITOR_FREE_DEV,
 	UTERM_MONITOR_HOTPLUG_DEV,
+	UTERM_MONITOR_UPDATE_SESSIONS,
 };
 
 enum uterm_monitor_dev_type {

--- a/src/uterm_systemd.c
+++ b/src/uterm_systemd.c
@@ -138,7 +138,6 @@ int uterm_sd_get_session_type(int pid, char **type)
 
 	if (!pid)
 		return -EINVAL;
-
 	ret = sd_pid_get_session(pid, &sess_id);
 	if (ret < 0)
 		return -EFAULT;
@@ -147,6 +146,7 @@ int uterm_sd_get_session_type(int pid, char **type)
 	if (ret < 0) {
 		log_warning("cannot read session type information from systemd: %d",
 			    ret);
+		free(sess_id);
 		return -EFAULT;
 	}
 	free(sess_id);

--- a/src/uterm_systemd.c
+++ b/src/uterm_systemd.c
@@ -130,3 +130,26 @@ int uterm_sd_get_seats(struct uterm_sd *sd, char ***seats)
 	*seats = s;
 	return ret;
 }
+
+int uterm_sd_get_session_type(int pid, char **type)
+{
+	int ret;
+	char *sess_id;
+
+	if (!pid)
+		return -EINVAL;
+
+	ret = sd_pid_get_session(pid, &sess_id);
+	if (ret < 0)
+		return -EFAULT;
+
+	ret = sd_session_get_type(sess_id, type);
+	if (ret < 0) {
+		log_warning("cannot read session type information from systemd: %d",
+			    ret);
+		return -EFAULT;
+	}
+	free(sess_id);
+
+	return ret;
+}

--- a/src/uterm_systemd.c
+++ b/src/uterm_systemd.c
@@ -46,7 +46,7 @@ struct uterm_sd {
 	sd_login_monitor *mon;
 };
 
-int uterm_sd_new(struct uterm_sd **out)
+int uterm_sd_new(struct uterm_sd **out, const char* event_type)
 {
 	int ret;
 	struct uterm_sd *sd;
@@ -71,7 +71,7 @@ int uterm_sd_new(struct uterm_sd **out)
 		return -ENOMEM;
 	memset(sd, 0, sizeof(*sd));
 
-	ret = sd_login_monitor_new("seat", &sd->mon);
+	ret = sd_login_monitor_new(event_type, &sd->mon);
 	if (ret) {
 		log_err("cannot create systemd login monitor (%d): %s",
 			ret, strerror(-ret));

--- a/src/uterm_systemd_internal.h
+++ b/src/uterm_systemd_internal.h
@@ -44,6 +44,7 @@ void uterm_sd_free(struct uterm_sd *sd);
 int uterm_sd_get_fd(struct uterm_sd *sd);
 void uterm_sd_flush(struct uterm_sd *sd);
 int uterm_sd_get_seats(struct uterm_sd *sd, char ***seats);
+int uterm_sd_get_session_type(pid_t pid, char **type);
 
 #else
 
@@ -66,6 +67,11 @@ static inline void uterm_sd_flush(struct uterm_sd *sd)
 }
 
 static inline int uterm_sd_get_seats(struct uterm_sd *sd, char ***seats)
+{
+	return -EINVAL;
+}
+
+static inline int uterm_sd_get_session_type(pid_t pid, char **type)
 {
 	return -EINVAL;
 }

--- a/src/uterm_systemd_internal.h
+++ b/src/uterm_systemd_internal.h
@@ -39,7 +39,7 @@ struct uterm_sd;
 
 #ifdef BUILD_ENABLE_MULTI_SEAT
 
-int uterm_sd_new(struct uterm_sd **out);
+int uterm_sd_new(struct uterm_sd **out, const char *event_type);
 void uterm_sd_free(struct uterm_sd *sd);
 int uterm_sd_get_fd(struct uterm_sd *sd);
 void uterm_sd_flush(struct uterm_sd *sd);
@@ -47,7 +47,7 @@ int uterm_sd_get_seats(struct uterm_sd *sd, char ***seats);
 
 #else
 
-static inline int uterm_sd_new(struct uterm_sd **out)
+static inline int uterm_sd_new(struct uterm_sd **out, const char *event_type)
 {
 	return -EOPNOTSUPP;
 }


### PR DESCRIPTION
This adds support for tracking systemd's session events in addition to the already supported seat events. This is done by adding a new systemd monitor to the event loop. The only functionality added so far is to check for updates on a session's type. On any session event, each seat will receive a UTERM_MONITOR_UPDATE_SESSIONS event. Each seat then checks the type of all of its sessions and checks whether it has been changed. If it has changed, the awake status of the session's terminal is updated appropriately.
When a graphical session is launched from a kmscon terminal, it will update the session type from "tty" to "wayland"/"x11". This property was used to update a terminal's awake status to false when a graphical session is launched within it. This prevents the terminal from reading keyboard events, thus fixing dvdhrm/kmscon#144. It also prevents other unnecessary background updates. When a graphical session is exited, the session's type is reverted to "tty", thus the terminal can then be updated to awake again.