### PR TITLE
feat: default to <Control>equal for the zoom-in grab

### DIFF
--- a/docs/man/kmscon.1.xml.in
+++ b/docs/man/kmscon.1.xml.in
@@ -379,7 +379,7 @@
         <term><option>--grab-zoom-in {grab}</option></term>
         <listitem>
           <para>Increase font size of the current terminal.
-                (default: &lt;Ctrl&gt;Plus)</para>
+                (default: &lt;Ctrl&gt;equal)</para>
         </listitem>
       </varlistentry>
 

--- a/src/kmscon_conf.c
+++ b/src/kmscon_conf.c
@@ -120,7 +120,7 @@ static void print_help()
 		"\t                                  Shortcut to scroll page up\n"
 		"\t    --grab-page-down <grab>     [<Shift>Next]\n"
 		"\t                                  Shortcut to scroll page down\n"
-		"\t    --grab-zoom-in <grab>       [<Ctrl>Plus]\n"
+		"\t    --grab-zoom-in <grab>       [<Ctrl>equal]\n"
 		"\t                                  Shortcut to increase font size\n"
 		"\t    --grab-zoom-out <grab>      [<Ctrl>Minus]\n"
 		"\t                                  Shortcut to decrease font size\n"
@@ -625,7 +625,7 @@ static struct conf_grab def_grab_page_down =
 		CONF_SINGLE_GRAB(SHL_SHIFT_MASK, XKB_KEY_Next);
 
 static struct conf_grab def_grab_zoom_in =
-		CONF_SINGLE_GRAB(SHL_CONTROL_MASK, XKB_KEY_plus);
+		CONF_SINGLE_GRAB(SHL_CONTROL_MASK, XKB_KEY_equal);
 
 static struct conf_grab def_grab_zoom_out =
 		CONF_SINGLE_GRAB(SHL_CONTROL_MASK, XKB_KEY_minus);


### PR DESCRIPTION
This saves the user from an extra Shift combo.