### PR TITLE
Fix running with simpledrm

### DIFF
--- a/src/kmscon_conf.c
+++ b/src/kmscon_conf.c
@@ -560,18 +560,12 @@ static int aftercheck_drm(struct conf_option *opt, int argc, char **argv,
 	struct kmscon_conf_t *conf = KMSCON_CONF_FROM_FIELD(opt->mem, drm);
 
 	/* disable --drm if DRM runtime support is not available */
-	/* TODO: This prevents people from booting without DRM and loading DRM
-	 * drivers during runtime. However, if we remove it, we will be unable
-	 * to automatically fall back to fbdev-mode.
-	 * But with blacklists fbdev-mode is the default so we can run with DRM
-	 * enabled but will still correctly use fbdev devices so we can then
-	 * remove this check. */
-	if (conf->drm) {
-		if (!uterm_video_available(UTERM_VIDEO_DRM3D) &&
-		    !uterm_video_available(UTERM_VIDEO_DRM2D)) {
-			log_info("no DRM runtime support available; disabling --drm");
-			conf->drm = false;
-		}
+	/* drmAvailable() is broken, as it only checks for GPU 0, but with
+	 * with simpledrm, it's often the case that the first gpu ends up being
+	 * GPU 1. So only checks if drm2d or drm3d is available */
+	if (conf->drm && !UTERM_VIDEO_DRM3D && !UTERM_VIDEO_DRM2D) {
+		log_info("no DRM runtime support available; disabling --drm");
+		conf->drm = false;
 	}
 
 	return 0;

--- a/src/uterm_video.c
+++ b/src/uterm_video.c
@@ -62,18 +62,6 @@ const char *uterm_dpms_to_name(int dpms)
 }
 
 SHL_EXPORT
-bool uterm_video_available(const struct uterm_video_module *mod)
-{
-	if (!mod)
-		return false;
-
-	if (mod == UTERM_VIDEO_DRM2D || mod == UTERM_VIDEO_DRM3D)
-		return video_drm_available();
-
-	return true;
-}
-
-SHL_EXPORT
 int mode_new(struct uterm_mode **out, const struct mode_ops *ops)
 {
 	struct uterm_mode *mode;

--- a/src/uterm_video.h
+++ b/src/uterm_video.h
@@ -133,7 +133,6 @@ typedef void (*uterm_display_cb) (struct uterm_display *disp,
 /* misc */
 
 const char *uterm_dpms_to_name(int dpms);
-bool uterm_video_available(const struct uterm_video_module *mod);
 
 /* display modes interface */
 

--- a/src/uterm_video_internal.h
+++ b/src/uterm_video_internal.h
@@ -179,23 +179,4 @@ static inline bool video_need_hotplug(const struct uterm_video *video)
 			.display = (disp), \
 			.action = (act), \
 		})
-
-#if defined(BUILD_ENABLE_VIDEO_DRM3D) || defined(BUILD_ENABLE_VIDEO_DRM2D)
-
-#include <xf86drm.h>
-
-static inline bool video_drm_available(void)
-{
-	return drmAvailable();
-}
-
-#else
-
-static inline bool video_drm_available(void)
-{
-	return false;
-}
-
-#endif
-
 #endif /* UTERM_VIDEO_INTERNAL_H */


### PR DESCRIPTION
The libdrm drmAvailable() function is broken, and only checks if GPU0 is present. Systems that uses simpledrm at boot, have their main GPU registered as GPU1, which means drm renderer is disabled, and a black screen is displayed.
The drmAvailable() function is now deprecated, and shouldn't be used anymore.
So remove this check, and simplify the code.

libdrm issue:
https://gitlab.freedesktop.org/mesa/drm/-/issues/113
libdrm mergerequest to deprecate drmAvailable():
https://gitlab.freedesktop.org/mesa/drm/-/merge_requests/402