### PR TITLE
Fix segfault in bind_display()

### DIFF
--- a/src/uterm_drm_shared.c
+++ b/src/uterm_drm_shared.c
@@ -585,6 +585,17 @@ int uterm_drm_video_find_crtc(struct uterm_video *video, drmModeRes *res,
 	return -1;
 }
 
+static drmModeCrtc *get_current_crtc(int fd, uint32_t encoder_id)
+{
+	drmModeEncoder *enc = drmModeGetEncoder(fd, encoder_id);
+	if (enc) {
+		int crtc_id = enc->crtc_id;
+		drmModeFreeEncoder(enc);
+		return drmModeGetCrtc(fd, crtc_id);
+	}
+	return NULL;
+}
+
 static void bind_display(struct uterm_video *video, drmModeRes *res,
 			 drmModeConnector *conn)
 {
@@ -592,6 +603,7 @@ static void bind_display(struct uterm_video *video, drmModeRes *res,
 	struct uterm_display *disp;
 	struct uterm_drm_display *ddrm;
 	struct uterm_mode *mode;
+	drmModeCrtc *current_crtc;
 	int ret, i;
 
 	ret = display_new(&disp, vdrm->display_ops);
@@ -599,9 +611,7 @@ static void bind_display(struct uterm_video *video, drmModeRes *res,
 		return;
 	ddrm = disp->data;
 
-	drmModeEncoder *enc = drmModeGetEncoder(vdrm->fd, conn->encoder_id);
-	drmModeCrtc *current_crtc = drmModeGetCrtc(vdrm->fd, enc->crtc_id);
-	drmModeFreeEncoder(enc);
+	current_crtc = get_current_crtc(vdrm->fd, conn->encoder_id);
 
 	for (i = 0; i < conn->count_modes; ++i) {
 		ret = mode_new(&mode, &uterm_drm_mode_ops);
@@ -621,11 +631,13 @@ static void bind_display(struct uterm_video *video, drmModeRes *res,
 			disp->default_mode = mode;
 
 		/* Save the original KMS mode for later use */
-		if (memcmp(&conn->modes[i], &current_crtc->mode, sizeof(conn->modes[i])) == 0)
+		if (current_crtc && memcmp(&conn->modes[i], &current_crtc->mode, sizeof(conn->modes[i])) == 0)
 		 	disp->original_mode = mode;
 
 		uterm_mode_unref(mode);
 	}
+	if (current_crtc)
+		drmModeFreeCrtc(current_crtc);
 
 	if (shl_dlist_empty(&disp->modes)) {
 		log_warn("no valid mode for display found");


### PR DESCRIPTION
Commit e92a53e2 introduced a regression.
The encoder of the current connector can be null.

This also fix a memory leak, as the crtc returned by drmModeGetCrtc() was never freed.