### PR TITLE
tests: remove unused X11 include

### DIFF
--- a/tests/test_input.c
+++ b/tests/test_input.c
@@ -36,7 +36,6 @@ static void print_help();
 #include <string.h>
 #include <sys/signalfd.h>
 #include <unistd.h>
-#include <X11/keysym.h>
 #include <xkbcommon/xkbcommon.h>
 #include "eloop.h"
 #include "shl_log.h"


### PR DESCRIPTION
This otherwise breaks compilation of `test_input.c` on systems without X.