### PR TITLE
Add setBackground and setForeground escape codes

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -191,6 +191,10 @@ foreach filename, kwargs : {
     'install_dir': bindir,
     'install_mode': 'rwxr-xr-x',
   },
+  'scripts/kmscon-launch-gui.sh': {
+    'install_dir': bindir,
+    'install_mode': 'rwxr-xr-x',
+  },
   'docs/kmscon.service.in': {
     'install_dir': systemdsystemunitdir,
     'install_mode': 'rw-r--r--',

--- a/scripts/kmscon-launch-gui.sh
+++ b/scripts/kmscon-launch-gui.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+if [ "$#" -eq 0 ]; then
+    echo "Usage: $0 argument"
+    exit 1
+fi
+
+printf "\x1B]drmDropMaster\a"
+eval "${@:1}"
+printf "\x1B]drmSetMaster\a"

--- a/scripts/kmscon-launch-gui.sh
+++ b/scripts/kmscon-launch-gui.sh
@@ -5,6 +5,6 @@ if [ "$#" -eq 0 ]; then
     exit 1
 fi
 
-printf "\x1B]drmDropMaster\a"
+printf "\x1B]setBackground\a"
 eval "${@:1}"
-printf "\x1B]drmSetMaster\a"
+printf "\x1B]setForeground\a"

--- a/src/kmscon_seat.c
+++ b/src/kmscon_seat.c
@@ -1203,7 +1203,8 @@ int kmscon_session_set_background(struct kmscon_session *sess)
 	return 0;
 }
 
-bool kmscon_session_get_foreground(struct kmscon_session *sess) {
+bool kmscon_session_get_foreground(struct kmscon_session *sess)
+{
 	return sess->foreground;
 }
 

--- a/src/kmscon_seat.c
+++ b/src/kmscon_seat.c
@@ -1203,6 +1203,10 @@ int kmscon_session_set_background(struct kmscon_session *sess)
 	return 0;
 }
 
+bool kmscon_session_get_foreground(struct kmscon_session *sess) {
+	return sess->foreground;
+}
+
 void kmscon_session_schedule(struct kmscon_session *sess)
 {
 	struct kmscon_seat *seat;

--- a/src/kmscon_seat.h
+++ b/src/kmscon_seat.h
@@ -114,6 +114,7 @@ bool kmscon_session_is_registered(struct kmscon_session *sess);
 bool kmscon_session_is_active(struct kmscon_session *sess);
 int kmscon_session_set_foreground(struct kmscon_session *sess);
 int kmscon_session_set_background(struct kmscon_session *sess);
+bool kmscon_session_get_foreground(struct kmscon_session *sess);
 void kmscon_session_schedule(struct kmscon_session *sess);
 
 void kmscon_session_enable(struct kmscon_session *sess);

--- a/src/kmscon_terminal.c
+++ b/src/kmscon_terminal.c
@@ -196,12 +196,12 @@ static void osc_event(struct tsm_vte *vte, const char *osc_string,
 {
 	struct kmscon_terminal *term = data;
 
-	if (strcmp(osc_string, "drmDropMaster") == 0) {
-		log_info("Got OSC drmDropMaster");
+	if (strcmp(osc_string, "setBackground") == 0) {
+		log_info("Got OSC setBackground");
 		kmscon_session_set_background(term->session);
 	}
-	else if (strcmp(osc_string, "drmSetMaster") == 0) {
-		log_info("Got OSC drmSetMaster");
+	else if (strcmp(osc_string, "setForeground") == 0) {
+		log_info("Got OSC setForeground");
 		kmscon_session_set_foreground(term->session);
 	}
 }
@@ -662,9 +662,9 @@ int kmscon_terminal_register(struct kmscon_session **out,
 
 	tsm_vte_set_backspace_sends_delete(term->vte,
 					   BUILD_BACKSPACE_SENDS_DELETE);
-	
+
 	tsm_vte_set_osc_cb(term->vte, osc_event, (void *)term);
-	
+
 	ret = tsm_vte_set_palette(term->vte, term->conf->palette);
 	if (ret)
 		goto err_vte;

--- a/src/kmscon_terminal.c
+++ b/src/kmscon_terminal.c
@@ -118,7 +118,7 @@ static void do_redraw_screen(struct screen *scr)
 {
 	int ret;
 
-	if (!scr->term->awake)
+	if (!scr->term->awake || !kmscon_session_get_foreground(scr->term->session))
 		return;
 
 	scr->pending = false;
@@ -189,6 +189,21 @@ static void display_event(struct uterm_display *disp,
 	scr->swapping = false;
 	if (scr->pending)
 		do_redraw_screen(scr);
+}
+
+static void osc_event(struct tsm_vte *vte, const char *osc_string,
+	size_t osc_len, void *data)
+{
+	struct kmscon_terminal *term = data;
+
+	if (strcmp(osc_string, "drmDropMaster") == 0) {
+		log_info("Got OSC drmDropMaster");
+		kmscon_session_set_background(term->session);
+	}
+	else if (strcmp(osc_string, "drmSetMaster") == 0) {
+		log_info("Got OSC drmSetMaster");
+		kmscon_session_set_foreground(term->session);
+	}
 }
 
 /*
@@ -647,7 +662,9 @@ int kmscon_terminal_register(struct kmscon_session **out,
 
 	tsm_vte_set_backspace_sends_delete(term->vte,
 					   BUILD_BACKSPACE_SENDS_DELETE);
-
+	
+	tsm_vte_set_osc_cb(term->vte, osc_event, (void *)term);
+	
 	ret = tsm_vte_set_palette(term->vte, term->conf->palette);
 	if (ret)
 		goto err_vte;


### PR DESCRIPTION
This adds two escape codes drmDropMaster and drmSetMaster. This allows telling kmscon to drop and set drm master when a command like printf enters the escape code into the pty. This also adds a shell script kmscon-launch-gui that automatically surrounds a command with these escape codes. This allows for a window manager like sway to be launched from kmscon in drm mode with the command ```kmscon-launch-gui sway```. I would appreciate feedback on the name of the shell script and I would also appreciate testing of different graphical applications. So far Hyprland, sway, gnome, and kde all work. 