### PR TITLE
Remove login session tracking

### DIFF
--- a/src/kmscon_main.c
+++ b/src/kmscon_main.c
@@ -501,13 +501,6 @@ static void app_monitor_event(struct uterm_monitor *mon,
 			break;
 		}
 		break;
-	case UTERM_MONITOR_UPDATE_SESSIONS:
-		seat = ev->seat_data;
-		if (!seat)
-			return;
-
-		kmscon_seat_update_sessions(seat->seat);
-		break;
 	}
 }
 

--- a/src/kmscon_seat.h
+++ b/src/kmscon_seat.h
@@ -104,7 +104,6 @@ int kmscon_seat_register_session(struct kmscon_seat *seat,
 				 struct kmscon_session **out,
 				 kmscon_session_cb_t cb,
 				 void *data);
-void kmscon_seat_update_sessions(struct kmscon_seat *seat);
 
 void kmscon_session_ref(struct kmscon_session *sess);
 void kmscon_session_unref(struct kmscon_session *sess);
@@ -114,6 +113,7 @@ bool kmscon_session_is_registered(struct kmscon_session *sess);
 bool kmscon_session_is_active(struct kmscon_session *sess);
 int kmscon_session_set_foreground(struct kmscon_session *sess);
 int kmscon_session_set_background(struct kmscon_session *sess);
+bool kmscon_session_get_foreground(struct kmscon_session *sess);
 void kmscon_session_schedule(struct kmscon_session *sess);
 
 void kmscon_session_enable(struct kmscon_session *sess);

--- a/src/kmscon_terminal.c
+++ b/src/kmscon_terminal.c
@@ -400,7 +400,7 @@ static void input_event(struct uterm_input *input,
 {
 	struct kmscon_terminal *term = data;
 
-	if (!term->opened || !term->awake || ev->handled)
+	if (!term->opened || !term->awake || ev->handled || !kmscon_session_get_foreground(term->session))
 		return;
 
 	if (conf_grab_matches(term->conf->grab_scroll_up,
@@ -585,27 +585,6 @@ static void write_event(struct tsm_vte *vte, const char *u8, size_t len,
 	struct kmscon_terminal *term = data;
 
 	kmscon_pty_write(term->pty, u8, len);
-}
-
-int kmscon_terminal_get_child_pid(void *term)
-{
-	struct kmscon_terminal *t = term;
-
-	if (!t)
-		return -EINVAL;
-
-	return kmscon_pty_get_child(t->pty);
-}
-
-int kmscon_terminal_set_awake(void *data, bool awake)
-{
-	struct kmscon_terminal *term = data;
-
-	if (!term)
-		return -EINVAL;
-
-	term->awake = awake;
-	return 0;
 }
 
 int kmscon_terminal_register(struct kmscon_session **out,

--- a/src/kmscon_terminal.h
+++ b/src/kmscon_terminal.h
@@ -42,24 +42,12 @@
 int kmscon_terminal_register(struct kmscon_session **out,
 			     struct kmscon_seat *seat,
 			     unsigned int vtnr);
-int kmscon_terminal_get_child_pid(void *term);
-int kmscon_terminal_set_awake(void *term, bool awake);
 
 #else /* !BUILD_ENABLE_SESSION_TERMINAL */
 
 static inline int kmscon_terminal_register(struct kmscon_session **out,
 					   struct kmscon_seat *seat,
 					   unsigned int vtnr)
-{
-	return -EOPNOTSUPP;
-}
-
-int kmscon_terminal_get_child_pid(void *term)
-{
-	return -EOPNOTSUPP;
-}
-
-int kmscon_terminal_set_awake(void *term, bool awake)
 {
 	return -EOPNOTSUPP;
 }

--- a/src/pty.c
+++ b/src/pty.c
@@ -229,14 +229,6 @@ int kmscon_pty_get_fd(struct kmscon_pty *pty)
 	return ev_eloop_get_fd(pty->eloop);
 }
 
-int kmscon_pty_get_child(struct kmscon_pty *pty)
-{
-	if (!pty)
-		return -EINVAL;
-
-	return pty->child;
-}
-
 void kmscon_pty_dispatch(struct kmscon_pty *pty)
 {
 	if (!pty)

--- a/src/pty.h
+++ b/src/pty.h
@@ -62,7 +62,6 @@ int kmscon_pty_set_vtnr(struct kmscon_pty *pty, unsigned int vtnr);
 void kmscon_pty_set_env_reset(struct kmscon_pty *pty, bool do_reset);
 
 int kmscon_pty_get_fd(struct kmscon_pty *pty);
-int kmscon_pty_get_child(struct kmscon_pty *pty);
 void kmscon_pty_dispatch(struct kmscon_pty *pty);
 
 int kmscon_pty_open(struct kmscon_pty *pty, unsigned short width,

--- a/src/uterm_monitor.h
+++ b/src/uterm_monitor.h
@@ -47,7 +47,6 @@ enum uterm_monitor_event_type {
 	UTERM_MONITOR_NEW_DEV,
 	UTERM_MONITOR_FREE_DEV,
 	UTERM_MONITOR_HOTPLUG_DEV,
-	UTERM_MONITOR_UPDATE_SESSIONS,
 };
 
 enum uterm_monitor_dev_type {

--- a/src/uterm_systemd.c
+++ b/src/uterm_systemd.c
@@ -46,7 +46,7 @@ struct uterm_sd {
 	sd_login_monitor *mon;
 };
 
-int uterm_sd_new(struct uterm_sd **out, const char* event_type)
+int uterm_sd_new(struct uterm_sd **out)
 {
 	int ret;
 	struct uterm_sd *sd;
@@ -71,7 +71,7 @@ int uterm_sd_new(struct uterm_sd **out, const char* event_type)
 		return -ENOMEM;
 	memset(sd, 0, sizeof(*sd));
 
-	ret = sd_login_monitor_new(event_type, &sd->mon);
+	ret = sd_login_monitor_new("seat", &sd->mon);
 	if (ret) {
 		log_err("cannot create systemd login monitor (%d): %s",
 			ret, strerror(-ret));
@@ -128,28 +128,5 @@ int uterm_sd_get_seats(struct uterm_sd *sd, char ***seats)
 	}
 
 	*seats = s;
-	return ret;
-}
-
-int uterm_sd_get_session_type(int pid, char **type)
-{
-	int ret;
-	char *sess_id;
-
-	if (!pid)
-		return -EINVAL;
-	ret = sd_pid_get_session(pid, &sess_id);
-	if (ret < 0)
-		return -EFAULT;
-
-	ret = sd_session_get_type(sess_id, type);
-	if (ret < 0) {
-		log_warning("cannot read session type information from systemd: %d",
-			    ret);
-		free(sess_id);
-		return -EFAULT;
-	}
-	free(sess_id);
-
 	return ret;
 }

--- a/src/uterm_systemd_internal.h
+++ b/src/uterm_systemd_internal.h
@@ -39,16 +39,15 @@ struct uterm_sd;
 
 #ifdef BUILD_ENABLE_MULTI_SEAT
 
-int uterm_sd_new(struct uterm_sd **out, const char *event_type);
+int uterm_sd_new(struct uterm_sd **out);
 void uterm_sd_free(struct uterm_sd *sd);
 int uterm_sd_get_fd(struct uterm_sd *sd);
 void uterm_sd_flush(struct uterm_sd *sd);
 int uterm_sd_get_seats(struct uterm_sd *sd, char ***seats);
-int uterm_sd_get_session_type(pid_t pid, char **type);
 
 #else
 
-static inline int uterm_sd_new(struct uterm_sd **out, const char *event_type)
+static inline int uterm_sd_new(struct uterm_sd **out)
 {
 	return -EOPNOTSUPP;
 }
@@ -67,11 +66,6 @@ static inline void uterm_sd_flush(struct uterm_sd *sd)
 }
 
 static inline int uterm_sd_get_seats(struct uterm_sd *sd, char ***seats)
-{
-	return -EINVAL;
-}
-
-static inline int uterm_sd_get_session_type(pid_t pid, char **type)
 {
 	return -EINVAL;
 }


### PR DESCRIPTION
After further testing with different window managers, I found that login session tracking only seems to work with wlroots based window managers. This reverts login session tracking and adds a check for input events that the session is in the foreground. This has the same effect of preventing input events when using kmscon-launch-gui from my other pull request. This fixes #104 and GH-103.