### PR TITLE
Make sure the main thread gets SIGCHLD

### DIFF
--- a/src/font_pango.c
+++ b/src/font_pango.c
@@ -403,6 +403,13 @@ static int kmscon_font_pango_init(struct kmscon_font *out,
 
 	log_debug("loading pango font %s", out->attr.name);
 
+	// glib creates a thread but we haven't blocked SIGCHLD yet
+	// (by signal_new) so it might go to glib instead of our signalfd.
+	sigset_t mask;
+	sigemptyset(&mask);
+	sigaddset(&mask, SIGCHLD);
+	pthread_sigmask(SIG_BLOCK, &mask, NULL);
+
 	ret = manager_get_face(&face, &out->attr);
 	if (ret)
 		return ret;


### PR DESCRIPTION
font_pango triggers creation of a glib thread which might capture SIGCHLD from child processes. Make sure those get blocked by blocking them in the parent process before thread creation.

Draft because this isn't really elegant and other signals might be affected as well?