### PR TITLE
Add selinux permissions

### DIFF
--- a/selinux/.gitignore
+++ b/selinux/.gitignore
@@ -1,0 +1,4 @@
+!Makefile
+tmp/*
+*.pp
+*.pp.bz2

--- a/selinux/COPYING
+++ b/selinux/COPYING
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Red Hat Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/selinux/Makefile
+++ b/selinux/Makefile
@@ -1,0 +1,26 @@
+TARGET?=kmscon
+MODULES?=${TARGET:=.pp.bz2}
+SHAREDIR?=/usr/share
+SELINUXTYPE?=targeted
+
+all: ${TARGET:=.pp.bz2}
+
+%.pp.bz2: %.pp
+	@echo Compressing $^ -\> $@
+	bzip2 -9 $^
+
+%.pp: %.te
+	make -f ${SHAREDIR}/selinux/devel/Makefile $@
+
+clean:
+	rm -f *~  *.tc *.pp *.pp.bz2
+	rm -rf tmp *.tar.gz
+
+man: install-policy
+	sepolicy manpage --path . --domain ${TARGET}_t
+
+install-policy: all
+	semodule -i ${TARGET}.pp.bz2
+
+install: all
+	install -D -m 644 ${TARGET}.pp.bz2 ${DESTDIR}${SHAREDIR}/selinux/packages/${SELINUXTYPE}/${TARGET}.pp.bz2

--- a/selinux/kmscon.fc
+++ b/selinux/kmscon.fc
@@ -1,0 +1,2 @@
+
+/usr/bin/kmscon	-- gen_context(system_u:object_r:shell_exec_t,s0)

--- a/selinux/kmscon.if
+++ b/selinux/kmscon.if
@@ -1,0 +1,1 @@
+## <summary></summary>

--- a/selinux/kmscon.te
+++ b/selinux/kmscon.te
@@ -1,0 +1,6 @@
+policy_module(kmscon,1.0)
+
+require {
+type shell_exec_t;
+}
+


### PR DESCRIPTION
Add proper selinux permissions, tested on Fedora 42.
It only needs to set /usr/bin/kmscon as shell_exec_t, otherwise selinux prevents to start /bin/bash when you login.