### PR TITLE
Fix x11 options and toggle layout

### DIFF
--- a/src/uterm_input.c
+++ b/src/uterm_input.c
@@ -265,6 +265,18 @@ int uterm_input_new(struct uterm_input **out,
 	if (ret)
 		goto err_free;
 
+	/* xkbcommon won't use the XKB_DEFAULT_OPTIONS environment
+	 * variable if options is an empty string.
+	 * So if all variables are empty, use NULL instead.
+	 */
+	if (model && *model == 0 && layout && *layout == 0 &&
+	    variant && *variant == 0 && options && *options == 0) {
+		model = NULL;
+		layout = NULL;
+		variant = NULL;
+		options = NULL;
+	}
+
 	ret = uxkb_desc_init(input, model, layout, variant, options, locale,
 			     keymap, compose_file, compose_file_len);
 	if (ret)


### PR DESCRIPTION
If you set multiple layout with localectl, and have an options to toggle layout, you can't toggle the layout in kmscon.

for example, with this localectl settings:
System Locale: LANG=el_GR.UTF-8
    VC Keymap: gr
   X11 Layout: gr,us
    X11 Model: pc105
  X11 Variant: ,
  X11 Options: grp:alt_space_toggle

The reason is that xkbcommon won't use the XKB_DEFAULT_OPTIONS environment variable if options is an empty string. So if all variables are empty, use NULL instead.

https://github.com/xkbcommon/libxkbcommon/blob/dd642359f8d43c09968e34ca7f1eb1121b2dfd70/src/context-priv.c#L176