### PR TITLE
Hide hardware cursor on vt switching

### DIFF
--- a/src/uterm_drm_shared.c
+++ b/src/uterm_drm_shared.c
@@ -732,6 +732,10 @@ int uterm_drm_video_hotplug(struct uterm_video *video,
 				continue;
 
 			disp->flags |= DISPLAY_AVAILABLE;
+
+			// Clean up kms hardware cursor from display sessions that don't properly clean themselves up`
+			drmModeSetCursor(vdrm->fd, ddrm->crtc_id, 0, 0, 0);
+
 			if (!display_is_online(disp))
 				break;
 


### PR DESCRIPTION
This fixes #56 by using the kms api to hide the hardware cursor on all displays on a hotplug event. I believe that uterm_drm_video_hotplug is always called on a vt switch from a graphical display session to kmscon, but further testing from others would be appreciated.