### PR TITLE
Add pts name login substitution

### DIFF
--- a/src/pty.c
+++ b/src/pty.c
@@ -338,12 +338,17 @@ static void setup_child(int master, struct winsize *ws, char **argv)
 	}
 
 	slave_name_dup = strdup(slave_name);
+	if (!slave_name_dup) {
+		log_err("cannot dup slave_name");
+		goto err_out;
+	}
+	
 	if (!strncmp(slave_name, "/dev/", 5))
 		slave_name_dup += 5;
 
 	/* Replace pts patterns in argv */
 	for (int i = 0; argv[i] != NULL; i++) {
-		if (!strncmp(argv[i], pts_pattern, strlen(pts_pattern))
+		if (!strncmp(argv[i], pts_pattern, strlen(pts_pattern)))
 			argv[i] = slave_name_dup;
 	}
 


### PR DESCRIPTION
Thanks to @kreijack for the idea and code. This adds the ability to use the string "{ptsname}" in the login command to get the name of the pts device used by kmscon. This is useful for printing out the pts name with agetty as described in #24. This is also needed for my plan of implementing running services in #122, since the pts name will need to be given to the service to properly run on the pty. If this approach isn't desired, we could also store the pts name to an environment variable similar to $XDG_VTNR.