### PR TITLE
Restart command line option

### DIFF
--- a/docs/man/kmscon.1.xml.in
+++ b/docs/man/kmscon.1.xml.in
@@ -228,6 +228,13 @@
       </varlistentry>
 
       <varlistentry>
+        <term><option>--restart</option></term>
+        <listitem>
+          <para>Restart the login process on exit. (default: on)</para>
+        </listitem>
+      </varlistentry>
+
+      <varlistentry>
         <term><option>-t {term}</option></term>
         <term><option>--term {term}</option></term>
         <listitem>

--- a/src/kmscon_conf.c
+++ b/src/kmscon_conf.c
@@ -88,6 +88,8 @@ static void print_help()
 		"\t                              argv to this process. No more options\n"
 		"\t                              after '--' will be parsed so use it at\n"
 		"\t                              the end of the argument string\n"
+		"\t    --restart               [on]\n"
+		"\t                              Restart the login process on exit\n"
 		"\t-t, --term <TERM>           [xterm-256color]\n"
 		"\t                              Value of the TERM environment variable\n"
 		"\t                              for the child process\n"
@@ -703,6 +705,7 @@ int kmscon_conf_new(struct conf_ctx **out)
 
 		/* Terminal Options */
 		CONF_OPTION(0, 'l', "login", &conf_login, aftercheck_login, NULL, file_login, &conf->login, false),
+		CONF_OPTION_BOOL(0, "restart", &conf->restart, true),
 		CONF_OPTION_STRING('t', "term", &conf->term, "xterm-256color"),
 		CONF_OPTION_BOOL(0, "reset-env", &conf->reset_env, true),
 		CONF_OPTION_UINT(0, "sb-size", &conf->sb_size, 1000),

--- a/src/kmscon_conf.h
+++ b/src/kmscon_conf.h
@@ -87,6 +87,8 @@ struct kmscon_conf_t {
 	bool login;
 	/* argv for login process */
 	char **argv;
+	/* restart login process */
+	bool restart;
 	/* TERM value */
 	char *term;
 	/* reset environment */

--- a/src/kmscon_terminal.c
+++ b/src/kmscon_terminal.c
@@ -575,7 +575,7 @@ static void pty_input(struct kmscon_pty *pty, const char *u8, size_t len,
 {
 	struct kmscon_terminal *term = data;
 
-	if (!len) {
+	if (!len && term->conf->restart) {
 		terminal_close(term);
 		terminal_open(term);
 	} else {


### PR DESCRIPTION
This adds the --restart command line option with the default value of on. This keeps the same functionality when it is not set or is set to on. When --no-restart is set, kmscon will not restart the child process when it exits. This is useful for launching services from kmscon and fixes #122, since you can configure the amount of restart attempts in the service file.