### PR TITLE
Fix github CI, after renaming develop to main

### DIFF
--- a/.github/workflows/meson.yml
+++ b/.github/workflows/meson.yml
@@ -2,9 +2,9 @@ name: Meson
 
 on:
   push:
-    branches: [ develop ]
+    branches: [ main ]
   pull_request:
-    branches: [ develop ]
+    branches: [ main ]
 
 jobs:
   build:


### PR DESCRIPTION
The develop branch was renamed to main, fix that in the github CI.