### PR TITLE
Readme: add systemd-dev requirement on debian systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,11 @@ For font handling the following is required:
 For multi-seat support you need the following packages:
 - systemd: Actually only the systemd-logind daemon and library is required.
 
+On Debian-based system, to install the systemd service files in the right location, you need to install systemd-dev.
+```bash
+sudo apt install systemd-dev
+```
+
 ## Download
 
 Released tarballs can be found at: https://github.com/Aetf/kmscon/releases

--- a/meson.build
+++ b/meson.build
@@ -39,7 +39,7 @@ mandir = get_option('mandir')
 moduledir = get_option('libdir') / meson.project_name()
 
 systemd_deps = dependency('systemd', required: false)
-systemdsystemunitdir = systemd_deps.get_variable('systemdsystemunitdir', default_value: get_option('libdir') / 'systemd/system')
+systemdsystemunitdir = systemd_deps.get_variable('systemdsystemunitdir', default_value: 'lib/systemd/system')
 
 #
 # Required dependencies


### PR DESCRIPTION
On a debian system, you also need to install systemd-dev, otherwise the service files wont be installed in the right location. https://github.com/abraunegg/onedrive/issues/3063

Fix #120