### PR TITLE
Allow glyphs to overflow

### DIFF
--- a/src/font_pango.c
+++ b/src/font_pango.c
@@ -115,7 +115,7 @@ static int get_glyph(struct face *face, struct kmscon_glyph **out,
 	struct kmscon_glyph *glyph;
 	PangoLayout *layout;
 	PangoAttrList *attrlist;
-	PangoRectangle rec;
+	PangoRectangle rec, logical_rec;
 	PangoLayoutLine *line;
 	FT_Bitmap bitmap;
 	unsigned int cwidth;
@@ -197,8 +197,9 @@ static int get_glyph(struct face *face, struct kmscon_glyph **out,
 
 	line = pango_layout_get_line_readonly(layout, 0);
 
-	pango_layout_line_get_pixel_extents(line, NULL, &rec);
+	pango_layout_line_get_pixel_extents(line, &logical_rec, &rec);
 	glyph->buf.width = face->real_attr.width * cwidth;
+	if (logical_rec.width > glyph->buf.width) glyph->buf.width = logical_rec.width;
 	glyph->buf.height = face->real_attr.height;
 	glyph->buf.stride = glyph->buf.width;
 	glyph->buf.format = UTERM_FORMAT_GREY;

--- a/src/kmscon_terminal.c
+++ b/src/kmscon_terminal.c
@@ -84,12 +84,11 @@ struct kmscon_terminal {
 	struct kmscon_font *bold_font;
 };
 
-static void do_clear_margins(struct screen *scr)
+static void do_clear_screen(struct screen *scr)
 {
-	unsigned int w, h, sw, sh;
+	unsigned int sw, sh;
 	struct uterm_mode *mode;
 	struct tsm_screen_attr attr;
-	int dw, dh;
 
 	mode = uterm_display_get_current(scr->disp);
 	if (!mode)
@@ -97,21 +96,9 @@ static void do_clear_margins(struct screen *scr)
 
 	sw = uterm_mode_get_width(mode);
 	sh = uterm_mode_get_height(mode);
-	w = scr->txt->font->attr.width * scr->txt->cols;
-	h = scr->txt->font->attr.height * scr->txt->rows;
-	dw = sw - w;
-	dh = sh - h;
-
 	tsm_vte_get_def_attr(scr->term->vte, &attr);
 
-	if (dw > 0)
-		uterm_display_fill(scr->disp, attr.br, attr.bg, attr.bb,
-				   w, 0,
-				   dw, h);
-	if (dh > 0)
-		uterm_display_fill(scr->disp, attr.br, attr.bg, attr.bb,
-				   0, h,
-				   sw, dh);
+	uterm_display_fill(scr->disp, attr.br, attr.bg, attr.bb, 0, 0, sw, sh);
 }
 
 static int font_set(struct kmscon_terminal *term);
@@ -124,7 +111,7 @@ static void do_redraw_screen(struct screen *scr)
 		return;
 
 	scr->pending = false;
-	do_clear_margins(scr);
+	do_clear_screen(scr);
 
 	kmscon_text_prepare(scr->txt);
 	tsm_screen_draw(scr->term->console, kmscon_text_draw_cb, scr->txt);


### PR DESCRIPTION
This is a proof of concept.

The idea is that we clear the surface before each render, and then blend glyph buffers with the existing surface (instead of overwriting). The current POC only works in DRM mode without hwaccel. By "works" I mean it does render over-spilling glyphs fully without chopping, but it's so slow it feels like a 1980s terminal.

Hopefully someone more familiar with the code can implement a proper solution. One idea I had was to keep a shadow buffer to prevent repeated read from the video memory, which cause the extreme slowness.