### PR TITLE
Disable session-control when running with real VTs

### DIFF
--- a/src/kmscon_seat.c
+++ b/src/kmscon_seat.c
@@ -777,6 +777,11 @@ int kmscon_seat_new(struct kmscon_seat **out,
 	if (ret)
 		goto err_input_cb;
 
+	if (seat->conf->session_control && uterm_vt_get_type(seat->vt) == UTERM_VT_REAL) {
+		log_warning("session control cannot be configured on real VT, disabling session control");
+		seat->conf->session_control = false;
+	}
+
 	ev_eloop_ref(seat->eloop);
 	uterm_vt_master_ref(seat->vtm);
 	*out = seat;


### PR DESCRIPTION
When using kmscon with ```--session-control``` on a system with real VTs, any terminal session other than the first session will not have a proper logind session created for it (see systemd/systemd#38748). Also, XDG_RUNTIME_DIR is not set which prevents graphical sessions from launching. This fixes #132.