### PR TITLE
Fix memory leak in kmscon_font_pango_get_overflow()

### DIFF
--- a/src/font_pango.c
+++ b/src/font_pango.c
@@ -466,24 +466,16 @@ static int kmscon_font_pango_render_inval(struct kmscon_font *font,
 					out);
 }
 
-static bool kmscon_font_pango_get_overflow(struct kmscon_font *font,
-			     const uint32_t *ch,
-				 size_t len)
+static bool kmscon_font_pango_layout_overflow(PangoLayout *layout,
+					      struct face* face,
+					      char *val,
+					      size_t ulen)
 {
-	PangoLayout *layout;
+	PangoLayoutLine *line;
 	PangoAttrList *attrlist;
 	PangoRectangle rec, logical_rec;
-	PangoLayoutLine *line;
-	struct face *face = font->data;
-	unsigned int cwidth;
-	size_t ulen, cnt;
-	char *val;
+	size_t cnt;
 
-	cwidth = tsm_ucs4_get_width(*ch);
-	if (!cwidth)
-		return false;
-
-	layout = pango_layout_new(face->ctx);
 	attrlist = pango_layout_get_attributes(layout);
 	if (attrlist == NULL) {
 		attrlist = pango_attr_list_new();
@@ -497,23 +489,45 @@ static bool kmscon_font_pango_get_overflow(struct kmscon_font *font,
 	/* no line spacing */
 	pango_layout_set_spacing(layout, 0);
 
-	val = tsm_ucs4_to_utf8_alloc(ch, len, &ulen);
-	if (!val) {
-		return false;
-	}
 	pango_layout_set_text(layout, val, ulen);
-	free(val);
 
 	cnt = pango_layout_get_line_count(layout);
-	if (cnt == 0) {
+	if (cnt == 0)
 		return false;
-	}
 
 	line = pango_layout_get_line_readonly(layout, 0);
 
 	pango_layout_line_get_pixel_extents(line, &logical_rec, &rec);
 
-	return (cwidth < 2) && (logical_rec.width > face->real_attr.width);
+	return logical_rec.width > face->real_attr.width;
+}
+
+static bool kmscon_font_pango_get_overflow(struct kmscon_font *font,
+					   const uint32_t *ch,
+					   size_t len)
+{
+	PangoLayout *layout;
+	struct face *face = font->data;
+	unsigned int cwidth;
+	char *val;
+	size_t ulen;
+	bool ret = false;
+
+	cwidth = tsm_ucs4_get_width(*ch);
+	if (!cwidth || cwidth == 2)
+		return false;
+
+	layout = pango_layout_new(face->ctx);
+	if (!layout)
+		return false;
+
+	val = tsm_ucs4_to_utf8_alloc(ch, len, &ulen);
+	if (val) {
+		ret = kmscon_font_pango_layout_overflow(layout, face, val, ulen);
+		free(val);
+	}
+	g_object_unref(layout);
+	return ret;
 }
 
 struct kmscon_font_ops kmscon_font_pango_ops = {


### PR DESCRIPTION
When checking the size of the character, the pango layout object was never freed.

Fixes #139