### PR TITLE
Pango: use font cache to check if the font overflows

### DIFF
--- a/src/font.c
+++ b/src/font.c
@@ -461,11 +461,11 @@ int kmscon_font_render_inval(struct kmscon_font *font,
  * Returns: true when overflow needed, false when no overflow needed or on error
  */
 bool kmscon_font_get_overflow(struct kmscon_font *font,
-			     const uint32_t *ch,
-				 size_t len)
+			      uint64_t id, const uint32_t *ch,
+			      size_t len)
 {
 	if (!font || !font->ops->get_overflow)
 		return false;
 
-	return font->ops->get_overflow(font, ch, len);
+	return font->ops->get_overflow(font, id, ch, len);
 }

--- a/src/font.h
+++ b/src/font.h
@@ -90,8 +90,8 @@ struct kmscon_font_ops {
 	int (*render_inval) (struct kmscon_font *font,
 			     const struct kmscon_glyph **out);
 	bool (*get_overflow) (struct kmscon_font *font,
-			     const uint32_t *ch,
-				 size_t len);
+			      uint64_t id, const uint32_t *ch,
+			      size_t len);
 };
 
 int kmscon_font_register(const struct kmscon_font_ops *ops);
@@ -111,8 +111,8 @@ int kmscon_font_render_empty(struct kmscon_font *font,
 int kmscon_font_render_inval(struct kmscon_font *font,
 			     const struct kmscon_glyph **out);
 bool kmscon_font_get_overflow(struct kmscon_font *font,
-			     const uint32_t *ch,
-				 size_t len);
+			      uint64_t id, const uint32_t *ch,
+			      size_t len);
 
 /* modularized backends */
 

--- a/src/text.c
+++ b/src/text.c
@@ -394,7 +394,7 @@ int kmscon_text_draw(struct kmscon_text *txt,
 		return -EINVAL;
 
 	previous_overflow = txt->overflow_next;
-	txt->overflow_next = kmscon_font_get_overflow(txt->font, ch, len);
+	txt->overflow_next = kmscon_font_get_overflow(txt->font, id, ch, len);
 	if (previous_overflow && !len && posx && !attr->inverse)
 		return 0;
 


### PR DESCRIPTION
Use the font cache instead of drawing the character each time to check if it can spill over the next character.
This also solves the memory leak because the pango layout object was ever freed.

Fixes #139