### PR TITLE
Pango: align stride to 4 bytes

### DIFF
--- a/src/font_pango.c
+++ b/src/font_pango.c
@@ -60,6 +60,8 @@
 
 #define LOG_SUBSYSTEM "font_pango"
 
+#define align_up4(x) (((x) + 3) & ~0x3)
+
 struct face {
 	unsigned long ref;
 	struct shl_dlist list;
@@ -201,7 +203,7 @@ static int get_glyph(struct face *face, struct kmscon_glyph **out,
 	glyph->width = (logical_rec.width > face->real_attr.width) ? 2 : cwidth;
 	glyph->buf.width = face->real_attr.width * glyph->width;
 	glyph->buf.height = face->real_attr.height;
-	glyph->buf.stride = glyph->buf.width;
+	glyph->buf.stride = align_up4(glyph->buf.width);
 	glyph->buf.format = UTERM_FORMAT_GREY;
 
 	if (!glyph->buf.width || !glyph->buf.height) {


### PR DESCRIPTION
Pixman requires stride to be a multiple of 4 bytes.

It fixes the following bug when using a font width that is not a multiple of 4

*** BUG ***
kmscon[1140]: In create_bits_image_internal: The expression bits == NULL || (rowstride_bytes % sizeof (uint32_t)) == 0 was false