### PR TITLE
Add rotation support

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -15,6 +15,8 @@ This software was written by:
 	Hoàng Đức Hiếu <github@zahe.me>
 	Swift Geek <swiftgeek@gmail.com>
 	Aetf <aetf@unlimited-code.works>
+	Mirco Müller <macslow@gmail.com>
+	Jocelyn Falempe <jfalempe@redhat.com>
 
 = Copyright Notice =
 

--- a/docs/man/kmscon.1.xml.in
+++ b/docs/man/kmscon.1.xml.in
@@ -439,6 +439,22 @@
                 (default: &lt;Ctrl&gt;&lt;Logo&gt;Return)</para>
         </listitem>
       </varlistentry>
+
+      <varlistentry>
+        <term><option>--grab-rotate-cw {grab}</option></term>
+        <listitem>
+          <para>Rotate output clock-wise: Normal -> Right -> Inverted -> Left and so on.
+                (default: &lt;Logo&gt;Plus)</para>
+        </listitem>
+      </varlistentry>
+
+      <varlistentry>
+        <term><option>--grab-rotate-ccw {grab}</option></term>
+        <listitem>
+          <para>Rotate output counter-clock-wise: Normal -> Left -> Inverted -> Right and so on.
+                (default: &lt;Logo&gt;Minus)</para>
+        </listitem>
+      </varlistentry>
     </variablelist>
 
     <para>Video Options:</para>
@@ -524,6 +540,18 @@
           mode effectively. For example, the `video={width}x{height}` kernel parameter may
           be required in order to ensure that there is enough memory to store the
           framebuffers for a large resolution.</para>
+        </listitem>
+      </varlistentry>
+
+      <varlistentry>
+        <term><option>--rotate {orientation}</option></term>
+        <listitem>
+          <para>Select the desired orientation of the output. Available orientations
+                are 'normal' meaning output is not rotated, 'right' meaning output is
+                rotated 90° clock-wise, 'upside-down' meaning output is rotated 180°
+                clock-wise and 'left' meaning output is rotated 90° counter clock-wise.
+                This has only effect for the 'gltex' render-engine. (default: 'normal')
+          </para>
         </listitem>
       </varlistentry>
     </variablelist>

--- a/docs/man/kmscon.conf.1.xml.in
+++ b/docs/man/kmscon.conf.1.xml.in
@@ -340,6 +340,20 @@ font-name=Ubuntu Mono
         </listitem>
       </varlistentry>
 
+      <varlistentry>
+        <term><option>grab-rotate-cw</option></term>
+        <listitem>
+          <para>Rotate output clock-wise. (default: &lt;Logo&gt;Plus)</para>
+        </listitem>
+      </varlistentry>
+
+      <varlistentry>
+        <term><option>grab-rotate-ccw</option></term>
+        <listitem>
+          <para>Rotate output counter-clock-wise. (default: &lt;Logo&gt;Minus)</para>
+        </listitem>
+      </varlistentry>
+
       <para><emphasis>### Video Options ###</emphasis></para>
       <varlistentry>
         <term><option>drm</option></term>
@@ -387,6 +401,13 @@ font-name=Ubuntu Mono
         <term><option>mode</option></term>
         <listitem>
           <para>Set the resolution to {width}x{height}</para>
+        </listitem>
+      </varlistentry>
+
+      <varlistentry>
+        <term><option>rotate</option></term>
+        <listitem>
+          <para>Orientation of output to use. (default: normal)</para>
         </listitem>
       </varlistentry>
 

--- a/src/font.h
+++ b/src/font.h
@@ -64,7 +64,6 @@ bool kmscon_font_attr_match(const struct kmscon_font_attr *a1,
 struct kmscon_glyph {
 	struct uterm_video_buffer buf;
 	unsigned int width;
-	void *data;
 };
 
 struct kmscon_font {

--- a/src/font_pango.c
+++ b/src/font_pango.c
@@ -60,8 +60,6 @@
 
 #define LOG_SUBSYSTEM "font_pango"
 
-#define align_up4(x) (((x) + 3) & ~0x3)
-
 struct face {
 	unsigned long ref;
 	struct shl_dlist list;
@@ -204,7 +202,7 @@ static int get_glyph(struct face *face, struct kmscon_glyph **out,
 	glyph->width = (logical_rec.x + logical_rec.width > rec.x + face->real_attr.width) ? 2 : cwidth;
 	glyph->buf.width = face->real_attr.width * glyph->width;
 	glyph->buf.height = face->real_attr.height;
-	glyph->buf.stride = align_up4(glyph->buf.width);
+	glyph->buf.stride = glyph->buf.width;
 	glyph->buf.format = UTERM_FORMAT_GREY;
 
 	if (!glyph->buf.width || !glyph->buf.height) {

--- a/src/font_rotate.c
+++ b/src/font_rotate.c
@@ -1,0 +1,120 @@
+/*
+ * kmscon - rotate font
+ *
+ * Copyright (c) 2025 Jocelyn Falempe <jfalempe@redhat.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files
+ * (the "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include "font_rotate.h"
+#include "shl_misc.h"
+
+ SHL_EXPORT
+int kmscon_rotate_create_tables(struct shl_hashtable **normal, struct shl_hashtable **bold, shl_free_cb free_glyph)
+{
+	int ret;
+
+	ret = shl_hashtable_new(normal, shl_direct_hash,
+				shl_direct_equal, free_glyph);
+	if (ret)
+		return ret;
+
+	ret = shl_hashtable_new(bold, shl_direct_hash,
+				shl_direct_equal, free_glyph);
+	if (ret)
+		shl_hashtable_free(*normal);
+	return ret;
+}
+
+SHL_EXPORT
+void kmscon_rotate_free_tables(struct shl_hashtable *normal, struct shl_hashtable *bold)
+{
+	shl_hashtable_free(normal);
+	shl_hashtable_free(bold);
+}
+
+SHL_EXPORT
+int kmscon_rotate_glyph(struct uterm_video_buffer *vb, const struct kmscon_glyph *glyph, enum Orientation orientation, uint8_t align)
+{
+	int width;
+	int height;
+	int stride;
+	int i, j;
+	uint8_t *dst, *src;
+	const struct uterm_video_buffer *buf = &glyph->buf;
+
+	if (orientation == OR_NORMAL || orientation == OR_UPSIDE_DOWN) {
+		width = buf->width;
+		height = buf->height;
+	} else {
+		width = buf->height;
+		height = buf->width;
+	}
+
+	stride =  align * ((width + (align - 1)) / align);
+	vb->data = malloc(stride * height);
+
+	if (!vb->data)
+		return -ENOMEM;
+
+	src = buf->data;
+	dst = vb->data;
+
+	switch (orientation) {
+	default:
+	case OR_NORMAL:
+		for (i = 0; i < buf->height; i++) {
+			memcpy(dst, src, buf->width);
+			dst += stride;
+			src += buf->stride;
+		}
+		break;
+	case OR_RIGHT:
+		for (i = 0; i < buf->height; i++) {
+			for (j = 0; j < buf->width; j++) {
+				dst[j * stride + (width - i - 1)] = src[j];
+			}
+			src += buf->stride;
+		}
+	break;
+	case OR_UPSIDE_DOWN:
+		src += (buf->height - 1) * buf->stride;
+		for (i = 0; i < buf->height; i++) {
+			for (j = 0; j < buf->width; j++)
+				dst[j] = src[buf->width - j - 1];
+			dst += stride;
+			src -= buf->stride;
+		}
+		break;
+	case OR_LEFT:
+		for (i = 0; i < buf->height; i++) {
+			for (j = 0; j < buf->width; j++) {
+				dst[(height -j -1) * stride + i] = src[j];
+			}
+			src += buf->stride;
+		}
+	}
+	vb->width = width;
+	vb->height = height;
+	vb->stride = stride;
+	vb->format = buf->format;
+	return 0;
+}
+

--- a/src/font_rotate.h
+++ b/src/font_rotate.h
@@ -1,0 +1,31 @@
+/*
+ * kmscon - rotate font
+ *
+ * Copyright (c) 2025 Jocelyn Falempe <jfalempe@redhat.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files
+ * (the "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include "shl_hashtable.h"
+#include "text.h"
+
+int kmscon_rotate_create_tables(struct shl_hashtable **normal, struct shl_hashtable **bold, shl_free_cb free_glyph);
+void kmscon_rotate_free_tables(struct shl_hashtable *normal, struct shl_hashtable *bold);
+int kmscon_rotate_glyph(struct uterm_video_buffer *vb, const struct kmscon_glyph *glyph, enum Orientation orientation, uint8_t align);

--- a/src/kmscon_conf.c
+++ b/src/kmscon_conf.c
@@ -134,6 +134,10 @@ static void print_help()
 		"\t                                  Close current session\n"
 		"\t    --grab-terminal-new <grab>  [<Ctrl><Logo>Return]\n"
 		"\t                                  Create a new terminal session\n"
+		"\t    --grab-rotate-cw <grab>     [<Logo>Plus]\n"
+		"\t                                  Rotate output clock-wise\n"
+		"\t    --grab-rotate-ccw <grab>    [<Logo>Minus]\n"
+		"\t                                  Rotate output counter-clock-wise\n"
 		"\n"
 		"Video Options:\n"
 		"\t    --drm                     [on]    Use DRM if available\n"
@@ -149,6 +153,7 @@ static void print_help()
 		"\t                                     error, a default mode will be used.\n"
 		"\t                                     This option is incompatible with\n"
 		"\t                                     --use-original-mode.\n"
+		"\t    --rotate <orientation>  [normal] normal, right, upside-down, left\n"
 		"\n"
 		"Font Options:\n"
 		"\t    --font-engine <engine>  [pango]\n"
@@ -646,6 +651,12 @@ static struct conf_grab def_grab_session_close =
 static struct conf_grab def_grab_terminal_new =
 		CONF_SINGLE_GRAB(SHL_CONTROL_MASK | SHL_LOGO_MASK, XKB_KEY_Return);
 
+static struct conf_grab def_grab_rotate_cw =
+		CONF_SINGLE_GRAB(SHL_LOGO_MASK, XKB_KEY_plus);
+
+static struct conf_grab def_grab_rotate_ccw =
+		CONF_SINGLE_GRAB(SHL_LOGO_MASK, XKB_KEY_minus);
+
 static palette_t def_palette = {
 	[TSM_COLOR_BLACK]         = {   0,   0,   0 }, /* black */
 	[TSM_COLOR_RED]           = { 205,   0,   0 }, /* red */
@@ -729,6 +740,8 @@ int kmscon_conf_new(struct conf_ctx **out)
 		CONF_OPTION_GRAB(0, "grab-session-dummy", &conf->grab_session_dummy, &def_grab_session_dummy),
 		CONF_OPTION_GRAB(0, "grab-session-close", &conf->grab_session_close, &def_grab_session_close),
 		CONF_OPTION_GRAB(0, "grab-terminal-new", &conf->grab_terminal_new, &def_grab_terminal_new),
+		CONF_OPTION_GRAB(0, "grab-rotate-cw", &conf->grab_rotate_cw, &def_grab_rotate_cw),
+		CONF_OPTION_GRAB(0, "grab-rotate-ccw", &conf->grab_rotate_ccw, &def_grab_rotate_ccw),
 
 		/* Video Options */
 		CONF_OPTION_BOOL_FULL(0, "drm", aftercheck_drm, NULL, NULL, &conf->drm, true),
@@ -737,6 +750,7 @@ int kmscon_conf_new(struct conf_ctx **out)
 		CONF_OPTION_STRING(0, "render-engine", &conf->render_engine, NULL),
 		CONF_OPTION_BOOL(0, "use-original-mode", &conf->use_original_mode, true),
 		CONF_OPTION_STRING(0, "mode", &conf->mode, NULL),
+		CONF_OPTION_STRING(0, "rotate", &conf->rotate, "normal"),
 
 		/* Font Options */
 		CONF_OPTION_STRING(0, "font-engine", &conf->font_engine, "pango"),

--- a/src/kmscon_conf.h
+++ b/src/kmscon_conf.h
@@ -135,6 +135,10 @@ struct kmscon_conf_t {
 	struct conf_grab *grab_session_close;
 	/* terminal-new grab */
 	struct conf_grab *grab_terminal_new;
+	/* rotate output clock-wise grab */
+	struct conf_grab *grab_rotate_cw;
+	/* rotate output counter-clock-wise grab */
+	struct conf_grab *grab_rotate_ccw;
 
 	/* Video Options */
 	/* use DRM if available */
@@ -149,6 +153,8 @@ struct kmscon_conf_t {
 	bool use_original_mode;
 	/* screen resolution */
 	char *mode;
+	/* orientation/rotation of output */
+	char *rotate;
 
 	/* Font Options */
 	/* font engine */

--- a/src/kmscon_terminal.c
+++ b/src/kmscon_terminal.c
@@ -101,11 +101,11 @@ static void do_clear_margins(struct screen *scr)
 	tsm_vte_get_def_attr(scr->term->vte, &attr);
 
 	if (scr->txt->orientation == OR_NORMAL || scr->txt->orientation == OR_UPSIDE_DOWN) {
-		w = scr->txt->font->attr.width * scr->txt->cols;
-		h = scr->txt->font->attr.height * scr->txt->rows;
+		w = FONT_WIDTH(scr->txt) * scr->txt->cols;
+		h = FONT_HEIGHT(scr->txt) * scr->txt->rows;
 	} else {
-		w = scr->txt->font->attr.height * scr->txt->rows;
-		h = scr->txt->font->attr.width * scr->txt->cols;
+		w = FONT_HEIGHT(scr->txt) * scr->txt->rows;
+		h = FONT_WIDTH(scr->txt) * scr->txt->cols;
 	}
 	dw = sw - w;
 	dh = sh - h;

--- a/src/kmscon_terminal.c
+++ b/src/kmscon_terminal.c
@@ -89,7 +89,7 @@ static void do_clear_margins(struct screen *scr)
 	unsigned int w, h, sw, sh;
 	struct uterm_mode *mode;
 	struct tsm_screen_attr attr;
-	int dw, dh;
+	int dh, dw;
 
 	mode = uterm_display_get_current(scr->disp);
 	if (!mode)
@@ -97,21 +97,35 @@ static void do_clear_margins(struct screen *scr)
 
 	sw = uterm_mode_get_width(mode);
 	sh = uterm_mode_get_height(mode);
-	w = scr->txt->font->attr.width * scr->txt->cols;
-	h = scr->txt->font->attr.height * scr->txt->rows;
-	dw = sw - w;
-	dh = sh - h;
 
 	tsm_vte_get_def_attr(scr->term->vte, &attr);
 
-	if (dw > 0)
-		uterm_display_fill(scr->disp, attr.br, attr.bg, attr.bb,
-				   w, 0,
-				   dw, h);
-	if (dh > 0)
-		uterm_display_fill(scr->disp, attr.br, attr.bg, attr.bb,
-				   0, h,
-				   sw, dh);
+	if (scr->txt->orientation == OR_NORMAL || scr->txt->orientation == OR_UPSIDE_DOWN) {
+		w = scr->txt->font->attr.width * scr->txt->cols;
+		h = scr->txt->font->attr.height * scr->txt->rows;
+	} else {
+		w = scr->txt->font->attr.height * scr->txt->rows;
+		h = scr->txt->font->attr.width * scr->txt->cols;
+	}
+	dw = sw - w;
+	dh = sh - h;
+
+	if (dw) {
+		if (scr->txt->orientation == OR_NORMAL || scr->txt->orientation == OR_LEFT)
+			uterm_display_fill(scr->disp, attr.br, attr.bg, attr.bb,
+				w, 0,dw, sh);
+		else
+			uterm_display_fill(scr->disp, attr.br, attr.bg, attr.bb,
+				0, 0,dw, sh);
+	}
+	if (dh) {
+		if (scr->txt->orientation == OR_NORMAL || scr->txt->orientation == OR_RIGHT)
+			uterm_display_fill(scr->disp, attr.br, attr.bg, attr.bb,
+				0, h, sw, dh);
+		else
+		 	uterm_display_fill(scr->disp, attr.br, attr.bg, attr.bb,
+				0, 0, sw, dh);
+	}
 }
 
 static int font_set(struct kmscon_terminal *term);
@@ -303,6 +317,57 @@ static int font_set(struct kmscon_terminal *term)
 	return 0;
 }
 
+static void rotate_cw_screen(struct screen *scr)
+{
+	unsigned int orientation = kmscon_text_get_orientation(scr->txt);
+	orientation = (orientation + 1) % (OR_LEFT + 1);
+	kmscon_text_rotate(scr->txt, orientation);
+}
+
+static void rotate_cw_all(struct kmscon_terminal *term)
+{
+	struct shl_dlist *iter;
+	struct screen *scr;
+
+	shl_dlist_for_each(iter, &term->screens) {
+		scr = shl_dlist_entry(iter, struct screen, list);
+		rotate_cw_screen(scr);
+		term->min_cols = 0;
+		term->min_rows = 0;
+		terminal_resize(term,
+				kmscon_text_get_cols(scr->txt),
+				kmscon_text_get_rows(scr->txt),
+				true, true);
+	}
+}
+
+static void rotate_ccw_screen(struct screen *scr)
+{
+	unsigned int orientation = kmscon_text_get_orientation(scr->txt);
+	if (orientation == OR_NORMAL)
+		orientation = OR_LEFT;
+	else
+		orientation -= 1;
+	kmscon_text_rotate(scr->txt, orientation);
+}
+
+static void rotate_ccw_all(struct kmscon_terminal *term)
+{
+	struct shl_dlist *iter;
+	struct screen *scr;
+
+	shl_dlist_for_each(iter, &term->screens) {
+		scr = shl_dlist_entry(iter, struct screen, list);
+		rotate_ccw_screen(scr);
+		term->min_cols = 0;
+		term->min_rows = 0;
+		terminal_resize(term,
+				kmscon_text_get_cols(scr->txt),
+				kmscon_text_get_rows(scr->txt),
+				true, true);
+	}
+}
+
 static int add_display(struct kmscon_terminal *term, struct uterm_display *disp)
 {
 	struct shl_dlist *iter;
@@ -340,7 +405,7 @@ static int add_display(struct kmscon_terminal *term, struct uterm_display *disp)
 	else
 		be = "bbulk";
 
-	ret = kmscon_text_new(&scr->txt, be);
+	ret = kmscon_text_new(&scr->txt, be, term->conf->rotate);
 	if (ret) {
 		log_error("cannot create text-renderer");
 		goto err_cb;
@@ -478,6 +543,18 @@ static void input_event(struct uterm_input *input,
 		--term->font_attr.points;
 		if (font_set(term))
 			++term->font_attr.points;
+		return;
+	}
+	if (conf_grab_matches(term->conf->grab_rotate_cw,
+				ev->mods, ev->num_syms, ev->keysyms)) {
+		rotate_cw_all(term);
+		ev->handled = true;
+		return;
+	}
+	if (conf_grab_matches(term->conf->grab_rotate_ccw,
+				ev->mods, ev->num_syms, ev->keysyms)) {
+		rotate_ccw_all(term);
+		ev->handled = true;
 		return;
 	}
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -242,6 +242,7 @@ conf_deps = declare_dependency(
 kmscon_srcs = [
   'pty.c',
   'font.c',
+  'font_rotate.c',
   'font_8x16.c',
   'text.c',
   'text_bblit.c',

--- a/src/shl_hashtable.h
+++ b/src/shl_hashtable.h
@@ -36,6 +36,7 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <string.h>
 #include "htable.h"
 
 struct shl_hashtable;

--- a/src/text.h
+++ b/src/text.h
@@ -86,6 +86,9 @@ struct kmscon_text_ops {
 	void (*abort) (struct kmscon_text *txt);
 };
 
+#define FONT_WIDTH(txt) ((txt)->font->attr.width)
+#define FONT_HEIGHT(txt) ((txt)->font->attr.height)
+
 int kmscon_text_register(const struct kmscon_text_ops *ops);
 void kmscon_text_unregister(const char *name);
 

--- a/src/text.h
+++ b/src/text.h
@@ -42,6 +42,13 @@
 
 /* text renderer */
 
+enum Orientation {
+	OR_NORMAL = 0,	// 0 Degree
+	OR_RIGHT,	// 90 Degree
+	OR_UPSIDE_DOWN,	// 180 Degree
+	OR_LEFT,	// 270 Degree
+};
+
 struct kmscon_text;
 struct kmscon_text_ops;
 
@@ -58,6 +65,7 @@ struct kmscon_text {
 	unsigned int rows;
 	bool rendering;
 	bool overflow_next;
+	enum Orientation orientation;
 };
 
 struct kmscon_text_ops {
@@ -67,6 +75,7 @@ struct kmscon_text_ops {
 	void (*destroy) (struct kmscon_text *txt);
 	int (*set) (struct kmscon_text *txt);
 	void (*unset) (struct kmscon_text *txt);
+	int (*rotate) (struct kmscon_text *txt, enum Orientation orientation);
 	int (*prepare) (struct kmscon_text *txt);
 	int (*draw) (struct kmscon_text *txt,
 		     uint64_t id, const uint32_t *ch, size_t len,
@@ -80,7 +89,7 @@ struct kmscon_text_ops {
 int kmscon_text_register(const struct kmscon_text_ops *ops);
 void kmscon_text_unregister(const char *name);
 
-int kmscon_text_new(struct kmscon_text **out, const char *backend);
+int kmscon_text_new(struct kmscon_text **out, const char *backend, const char *rotate);
 void kmscon_text_ref(struct kmscon_text *txt);
 void kmscon_text_unref(struct kmscon_text *txt);
 
@@ -91,6 +100,9 @@ int kmscon_text_set(struct kmscon_text *txt,
 void kmscon_text_unset(struct kmscon_text *txt);
 unsigned int kmscon_text_get_cols(struct kmscon_text *txt);
 unsigned int kmscon_text_get_rows(struct kmscon_text *txt);
+
+enum Orientation kmscon_text_get_orientation(struct kmscon_text *txt);
+int kmscon_text_rotate(struct kmscon_text *txt, enum Orientation orientation);
 
 int kmscon_text_prepare(struct kmscon_text *txt);
 int kmscon_text_draw(struct kmscon_text *txt,

--- a/src/text_bblit.c
+++ b/src/text_bblit.c
@@ -36,14 +36,48 @@
 #include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
+#include "font_rotate.h"
 #include "shl_log.h"
 #include "text.h"
 #include "uterm_video.h"
 
 #define LOG_SUBSYSTEM "text_bblit"
 
+struct bblit {
+	struct shl_hashtable *glyphs;
+	struct shl_hashtable *bold_glyphs;
+};
+
+static int bblit_init(struct kmscon_text *txt)
+{
+	struct bblit *bb;
+
+	bb = malloc(sizeof(*bb));
+	if (!bb)
+		return -ENOMEM;
+
+	txt->data = bb;
+	return 0;
+}
+
+static void bblit_destroy(struct kmscon_text *txt)
+{
+	struct bblit *bb = txt->data;
+
+	free(bb);
+}
+
+static void free_glyph(void *data)
+{
+	struct uterm_video_buffer *bb_glyph = data;
+
+	free(bb_glyph->data);
+	free(bb_glyph);
+}
+
 static int bblit_set(struct kmscon_text *txt)
 {
+	struct bblit *bb = txt->data;
 	unsigned int sw, sh;
 	struct uterm_mode *mode;
 
@@ -53,29 +87,49 @@ static int bblit_set(struct kmscon_text *txt)
 	sw = uterm_mode_get_width(mode);
 	sh = uterm_mode_get_height(mode);
 
-	txt->cols = sw / FONT_WIDTH(txt);
-	txt->rows = sh / FONT_HEIGHT(txt);
+	if (txt->orientation == OR_NORMAL || txt->orientation == OR_UPSIDE_DOWN) {
+		txt->cols = sw / FONT_WIDTH(txt);
+		txt->rows = sh / FONT_HEIGHT(txt);
+	} else {
+		txt->rows = sw / FONT_HEIGHT(txt);
+		txt->cols = sh / FONT_WIDTH(txt);
+	}
 
-	return 0;
+	return kmscon_rotate_create_tables(&bb->glyphs, &bb->bold_glyphs, free_glyph);
 }
 
-static int bblit_draw(struct kmscon_text *txt,
-		      uint64_t id, const uint32_t *ch, size_t len,
-		      unsigned int width,
-		      unsigned int posx, unsigned int posy,
-		      const struct tsm_screen_attr *attr)
+static void bblit_unset(struct kmscon_text *txt)
 {
+	struct bblit *bb = txt->data;
+
+	kmscon_rotate_free_tables(bb->glyphs, bb->bold_glyphs);
+}
+
+static int bblit_rotate(struct kmscon_text *txt, enum Orientation orientation)
+{
+	bblit_unset(txt);
+	txt->orientation = orientation;
+	return bblit_set(txt);
+}
+
+static int find_glyph(struct kmscon_text *txt, struct uterm_video_buffer **out,
+		      uint64_t id, const uint32_t *ch, size_t len, const struct tsm_screen_attr *attr)
+{
+	struct bblit *bb = txt->data;
+	struct uterm_video_buffer *bb_glyph;
 	const struct kmscon_glyph *glyph;
-	int ret;
+	struct shl_hashtable *gtable;
 	struct kmscon_font *font;
+	int ret;
+	bool res;
 
-	if (!width)
-		return 0;
-
-	if (attr->bold)
+	if (attr->bold) {
+		gtable = bb->bold_glyphs;
 		font = txt->bold_font;
-	else
+	} else {
+		gtable = bb->glyphs;
 		font = txt->font;
+	}
 
 	if (attr->underline)
 		font->attr.underline = true;
@@ -87,29 +141,100 @@ static int bblit_draw(struct kmscon_text *txt,
 	else
 		font->attr.italic = false;
 
-	if (!len) {
-		ret = kmscon_font_render_empty(font, &glyph);
-	} else {
-		ret = kmscon_font_render(font, id, ch, len, &glyph);
+	res = shl_hashtable_find(gtable, (void**)&bb_glyph, id);
+	if (res) {
+		*out = bb_glyph;
+		return 0;
 	}
+
+	bb_glyph = malloc(sizeof(*bb_glyph));
+	if (!bb_glyph)
+		return -ENOMEM;
+	memset(bb_glyph, 0, sizeof(*bb_glyph));
+
+	if (!len)
+		ret = kmscon_font_render_empty(font, &glyph);
+	else
+		ret = kmscon_font_render(font, id, ch, len, &glyph);
 
 	if (ret) {
 		ret = kmscon_font_render_inval(font, &glyph);
 		if (ret)
-			return ret;
+			goto err_free;
+	}
+
+	ret = kmscon_rotate_glyph( bb_glyph, glyph, txt->orientation, 1);
+	if (ret)
+		goto err_free;
+
+	ret = shl_hashtable_insert(gtable, id, bb_glyph);
+	if (ret)
+		goto err_free_vb;
+
+	*out = bb_glyph;
+	return 0;
+
+err_free_vb:
+	free(bb_glyph->data);
+err_free:
+	free(bb_glyph);
+	return ret;
+}
+
+
+static int bblit_draw(struct kmscon_text *txt,
+		      uint64_t id, const uint32_t *ch, size_t len,
+		      unsigned int width,
+		      unsigned int posx, unsigned int posy,
+		      const struct tsm_screen_attr *attr)
+{
+	struct uterm_video_buffer *bb_glyph;
+	struct uterm_mode *mode;
+	unsigned sw, sh, x, y, cwidth;
+	int ret;
+
+	if (!width)
+		return 0;
+
+	mode = uterm_display_get_current(txt->disp);
+	if (!mode)
+		return -EINVAL;
+	sw = uterm_mode_get_width(mode);
+	sh = uterm_mode_get_height(mode);
+
+	ret = find_glyph(txt, &bb_glyph, id, ch, len, attr);
+	if (ret)
+		return ret;
+
+	switch (txt->orientation) {
+	default:
+	case OR_NORMAL:
+		x = posx * FONT_WIDTH(txt);
+		y = posy * FONT_HEIGHT(txt);
+		break;
+	case OR_UPSIDE_DOWN:
+		cwidth = bb_glyph->width / FONT_WIDTH(txt);
+		x = sw - (posx + cwidth) * FONT_WIDTH(txt);
+		y = sh - (posy + 1) * FONT_HEIGHT(txt);
+		break;
+	case OR_RIGHT:
+		x = sw - (posy + 1) * FONT_HEIGHT(txt);
+		y = posx * FONT_WIDTH(txt);
+		break;
+	case OR_LEFT:
+		cwidth = bb_glyph->height / FONT_WIDTH(txt);
+		x = posy * FONT_HEIGHT(txt);
+		y = sh - (posx + cwidth) * FONT_WIDTH(txt);
+		break;
 	}
 
 	/* draw glyph */
 	if (attr->inverse) {
-		ret = uterm_display_fake_blend(txt->disp, &glyph->buf,
-					       posx * txt->font->attr.width,
-					       posy * txt->font->attr.height,
+		ret = uterm_display_fake_blend(txt->disp, bb_glyph, x, y,
 					       attr->br, attr->bg, attr->bb,
 					       attr->fr, attr->fg, attr->fb);
 	} else {
-		ret = uterm_display_fake_blend(txt->disp, &glyph->buf,
-					       posx * txt->font->attr.width,
-					       posy * txt->font->attr.height,
+		ret = uterm_display_fake_blend(txt->disp, bb_glyph, x, y,
 					       attr->fr, attr->fg, attr->fb,
 					       attr->br, attr->bg, attr->bb);
 	}
@@ -120,10 +245,11 @@ static int bblit_draw(struct kmscon_text *txt,
 struct kmscon_text_ops kmscon_text_bblit_ops = {
 	.name = "bblit",
 	.owner = NULL,
-	.init = NULL,
-	.destroy = NULL,
+	.init = bblit_init,
+	.destroy = bblit_destroy,
 	.set = bblit_set,
-	.unset = NULL,
+	.unset = bblit_unset,
+	.rotate = bblit_rotate,
 	.prepare = NULL,
 	.draw = bblit_draw,
 	.render = NULL,

--- a/src/text_bblit.c
+++ b/src/text_bblit.c
@@ -44,19 +44,17 @@
 
 static int bblit_set(struct kmscon_text *txt)
 {
-	unsigned int sw, sh, fw, fh;
+	unsigned int sw, sh;
 	struct uterm_mode *mode;
 
-	fw = txt->font->attr.width;
-	fh = txt->font->attr.height;
 	mode = uterm_display_get_current(txt->disp);
 	if (!mode)
 		return -EINVAL;
 	sw = uterm_mode_get_width(mode);
 	sh = uterm_mode_get_height(mode);
 
-	txt->cols = sw / fw;
-	txt->rows = sh / fh;
+	txt->cols = sw / FONT_WIDTH(txt);
+	txt->rows = sh / FONT_HEIGHT(txt);
 
 	return 0;
 }

--- a/src/text_bbulk.c
+++ b/src/text_bbulk.c
@@ -32,10 +32,14 @@
  * pushes all of them at once to the video device.
  */
 
+#include <asm-generic/errno.h>
 #include <errno.h>
 #include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
+#include "font.h"
+#include "font_rotate.h"
+#include "shl_hashtable.h"
 #include "shl_log.h"
 #include "text.h"
 #include "uterm_video.h"
@@ -44,6 +48,8 @@
 
 struct bbulk {
 	struct uterm_video_blend_req *reqs;
+	struct shl_hashtable *glyphs;
+	struct shl_hashtable *bold_glyphs;
 };
 
 static int bbulk_init(struct kmscon_text *txt)
@@ -65,6 +71,14 @@ static void bbulk_destroy(struct kmscon_text *txt)
 	free(bb);
 }
 
+static void free_glyph(void *data)
+{
+	struct uterm_video_buffer *bb_glyph = data;
+
+	free(bb_glyph->data);
+	free(bb_glyph);
+}
+
 static int bbulk_set(struct kmscon_text *txt)
 {
 	struct bbulk *bb = txt->data;
@@ -80,9 +94,13 @@ static int bbulk_set(struct kmscon_text *txt)
 	sw = uterm_mode_get_width(mode);
 	sh = uterm_mode_get_height(mode);
 
-	txt->cols = sw / FONT_WIDTH(txt);
-	txt->rows = sh / FONT_HEIGHT(txt);
-
+	if (txt->orientation == OR_NORMAL || txt->orientation == OR_UPSIDE_DOWN) {
+		txt->cols = sw / FONT_WIDTH(txt);
+		txt->rows = sh / FONT_HEIGHT(txt);
+	} else {
+		txt->rows = sw / FONT_HEIGHT(txt);
+		txt->cols = sh / FONT_WIDTH(txt);
+	}
 	bb->reqs = malloc(sizeof(*bb->reqs) * txt->cols * txt->rows);
 	if (!bb->reqs)
 		return -ENOMEM;
@@ -91,43 +109,71 @@ static int bbulk_set(struct kmscon_text *txt)
 	for (i = 0; i < txt->rows; ++i) {
 		for (j = 0; j < txt->cols; ++j) {
 			req = &bb->reqs[i * txt->cols + j];
-			req->x = j * FONT_WIDTH(txt);
-			req->y = i * FONT_HEIGHT(txt);
+			switch (txt->orientation) {
+			default:
+			case OR_NORMAL:
+				req->x = j * FONT_WIDTH(txt);
+				req->y = i * FONT_HEIGHT(txt);
+				break;
+			case OR_UPSIDE_DOWN:
+				req->x = sw - (j + 1) * FONT_WIDTH(txt);
+				req->y = sh - (i + 1) * FONT_HEIGHT(txt);
+				break;
+			case OR_RIGHT:
+				req->x = sw - (i + 1) * FONT_HEIGHT(txt);
+				req->y = j * FONT_WIDTH(txt);
+				break;
+			case OR_LEFT:
+				req->x = i * FONT_HEIGHT(txt);
+				req->y = sh - (j + 1) * FONT_WIDTH(txt);
+				break;
+			}
+
 		}
 	}
-
+	if (kmscon_rotate_create_tables(&bb->glyphs, &bb->bold_glyphs, free_glyph))
+		goto free_reqs;
 	return 0;
+
+free_reqs:
+	free(bb->reqs);
+	return -ENOMEM;
 }
 
 static void bbulk_unset(struct kmscon_text *txt)
 {
 	struct bbulk *bb = txt->data;
 
+	kmscon_rotate_free_tables(bb->glyphs, bb->bold_glyphs);
 	free(bb->reqs);
 	bb->reqs = NULL;
 }
 
-static int bbulk_draw(struct kmscon_text *txt,
-		      uint64_t id, const uint32_t *ch, size_t len,
-		      unsigned int width,
-		      unsigned int posx, unsigned int posy,
-		      const struct tsm_screen_attr *attr)
+static int bbulk_rotate(struct kmscon_text *txt, enum Orientation orientation)
+{
+	bbulk_unset(txt);
+	txt->orientation = orientation;
+	return bbulk_set(txt);
+}
+
+static int find_glyph(struct kmscon_text *txt, struct uterm_video_buffer **out,
+		      uint64_t id, const uint32_t *ch, size_t len, const struct tsm_screen_attr *attr)
 {
 	struct bbulk *bb = txt->data;
+	struct uterm_video_buffer *bb_glyph;
 	const struct kmscon_glyph *glyph;
-	int ret;
-	struct uterm_video_blend_req *req;
+	struct shl_hashtable *gtable;
 	struct kmscon_font *font;
+	int ret;
+	bool res;
 
-	if (!width) {
-		bb->reqs[posy * txt->cols + posx].buf = NULL;
-		return 0;
-	}
-
-	if (attr->bold)
+	if (attr->bold) {
+		gtable = bb->bold_glyphs;
 		font = txt->bold_font;
-	else
+	} else {
+		gtable = bb->glyphs;
 		font = txt->font;
+	}
 
 	if (attr->underline)
 		font->attr.underline = true;
@@ -139,20 +185,79 @@ static int bbulk_draw(struct kmscon_text *txt,
 	else
 		font->attr.italic = false;
 
-	if (!len) {
-		ret = kmscon_font_render_empty(font, &glyph);
-	} else {
-		ret = kmscon_font_render(font, id, ch, len, &glyph);
+	res = shl_hashtable_find(gtable, (void**)&bb_glyph, id);
+	if (res) {
+		*out = bb_glyph;
+		return 0;
 	}
+
+	bb_glyph = malloc(sizeof(*bb_glyph));
+	if (!bb_glyph)
+		return -ENOMEM;
+	memset(bb_glyph, 0, sizeof(*bb_glyph));
+
+	if (!len)
+		ret = kmscon_font_render_empty(font, &glyph);
+	else
+		ret = kmscon_font_render(font, id, ch, len, &glyph);
 
 	if (ret) {
 		ret = kmscon_font_render_inval(font, &glyph);
 		if (ret)
-			return ret;
+			goto err_free;
 	}
 
+	ret = kmscon_rotate_glyph( bb_glyph, glyph, txt->orientation, 1);
+	if (ret)
+		goto err_free;
+
+	ret = shl_hashtable_insert(gtable, id, bb_glyph);
+	if (ret)
+		goto err_free_vb;
+
+	*out = bb_glyph;
+	return 0;
+
+err_free_vb:
+	free(bb_glyph->data);
+err_free:
+	free(bb_glyph);
+	return ret;
+}
+
+static int bbulk_draw(struct kmscon_text *txt,
+		      uint64_t id, const uint32_t *ch, size_t len,
+		      unsigned int width,
+		      unsigned int posx, unsigned int posy,
+		      const struct tsm_screen_attr *attr)
+{
+	struct bbulk *bb = txt->data;
+	struct uterm_video_buffer *bb_glyph;
+	struct uterm_video_blend_req *req;
+	int ret;
+
+	if (!width) {
+		bb->reqs[posy * txt->cols + posx].buf = NULL;
+		return 0;
+	}
+	ret = find_glyph(txt, &bb_glyph, id, ch, len, attr);
+	if (ret)
+		return ret;
+
 	req = &bb->reqs[posy * txt->cols + posx];
-	req->buf = &glyph->buf;
+
+	/*
+	 * In case of left or upside down orientation, we need to draw to the
+	 * next cell, as the glyph is already rotated, so start on the next cell
+	 * and end on this cell
+	 */
+	if (txt->orientation == OR_LEFT || txt->orientation == OR_UPSIDE_DOWN) {
+		if (txt->overflow_next && posx + 1 < txt->cols) {
+			req = &bb->reqs[posy * txt->cols + posx + 1];
+		}
+	}
+
+	req->buf = bb_glyph;
 	if (attr->inverse) {
 		req->fr = attr->br;
 		req->fg = attr->bg;
@@ -168,8 +273,6 @@ static int bbulk_draw(struct kmscon_text *txt,
 		req->bg = attr->bg;
 		req->bb = attr->bb;
 	}
-	if (txt->overflow_next && posx + 1 < txt->cols)
-		bb->reqs[posy * txt->cols + posx + 1].buf = NULL;
 
 	return 0;
 }
@@ -177,9 +280,23 @@ static int bbulk_draw(struct kmscon_text *txt,
 static int bbulk_render(struct kmscon_text *txt)
 {
 	struct bbulk *bb = txt->data;
+	int ret;
 
-	return uterm_display_fake_blendv(txt->disp, bb->reqs,
+	ret = uterm_display_fake_blendv(txt->disp, bb->reqs,
 					 txt->cols * txt->rows);
+	return ret;
+}
+
+static int bbulk_prepare(struct kmscon_text *txt)
+{
+	struct bbulk *bb = txt->data;
+	int i;
+
+	// Clear previous requests
+	for (i = 0; i < txt->rows * txt->cols; ++i)
+		bb->reqs[i].buf = NULL;
+
+	return 0;
 }
 
 struct kmscon_text_ops kmscon_text_bbulk_ops = {
@@ -189,7 +306,8 @@ struct kmscon_text_ops kmscon_text_bbulk_ops = {
 	.destroy = bbulk_destroy,
 	.set = bbulk_set,
 	.unset = bbulk_unset,
-	.prepare = NULL,
+	.rotate = bbulk_rotate,
+	.prepare = bbulk_prepare,
 	.draw = bbulk_draw,
 	.render = bbulk_render,
 	.abort = NULL,

--- a/src/text_bbulk.c
+++ b/src/text_bbulk.c
@@ -46,9 +46,6 @@ struct bbulk {
 	struct uterm_video_blend_req *reqs;
 };
 
-#define FONT_WIDTH(txt) ((txt)->font->attr.width)
-#define FONT_HEIGHT(txt) ((txt)->font->attr.height)
-
 static int bbulk_init(struct kmscon_text *txt)
 {
 	struct bbulk *bb;

--- a/src/text_gltex.c
+++ b/src/text_gltex.c
@@ -114,9 +114,6 @@ struct gltex {
 	unsigned int sh;
 };
 
-#define FONT_WIDTH(txt) ((txt)->font->attr.width)
-#define FONT_HEIGHT(txt) ((txt)->font->attr.height)
-
 static int gltex_init(struct kmscon_text *txt)
 {
 	struct gltex *gt;

--- a/src/text_gltex_atlas.vert
+++ b/src/text_gltex_atlas.vert
@@ -31,6 +31,8 @@
  */
 
 uniform mat4 projection;
+uniform float cos;
+uniform float sin;
 
 attribute vec2 position;
 attribute vec2 texture_position;
@@ -41,9 +43,15 @@ varying vec2 texpos;
 varying vec3 fgcol;
 varying vec3 bgcol;
 
+vec2 opRotate(in vec2 p)
+{
+    return p * mat2(vec2(cos, sin), vec2(-sin, cos));
+}
+
 void main()
 {
-	gl_Position = projection * vec4(position, 0.0, 1.0);
+	vec2 rotatedPosition = opRotate(position);
+	gl_Position = projection * vec4(rotatedPosition, 0.0, 1.0);
 	texpos = texture_position;
 	fgcol = fgcolor;
 	bgcol = bgcolor;

--- a/src/text_pixman.c
+++ b/src/text_pixman.c
@@ -223,8 +223,8 @@ static int tp_set(struct kmscon_text *txt)
 		}
 	}
 
-	txt->cols = w / txt->font->attr.width;
-	txt->rows = h / txt->font->attr.height;
+	txt->cols = w / FONT_WIDTH(txt);
+	txt->rows = h / FONT_HEIGHT(txt);
 
 	return 0;
 


### PR DESCRIPTION
I've adapted the patches from MacSlow, and added support for the pixman, bbulk and bblit renderers.

- Simplified the orientation enum.
- Remove angle from gltex, and uses direct cos and sin value (1.0 or 0.0), as we only do multiple of 90 degree rotation.
- Added an helper, to avoid duplication between pixman, bbulk and bblit.
- Tested with the recent "double width overflow" fonts.

It's the rotation part of #75.