### PR TITLE
kmscon-launch-gui: don't use eval

### DIFF
--- a/scripts/kmscon-launch-gui.sh
+++ b/scripts/kmscon-launch-gui.sh
@@ -16,7 +16,7 @@ else
     printf "\033Ptmux;\033\033]setBackground\a\033\\"
 fi
 
-eval "$@"
+"$@"
 
 # If the current tty has changed, wait until the user switches back.
 if [ -n "${kms_tty}" ]; then


### PR DESCRIPTION
this eval is harmful as it makes it necessary to add one more level of escaping to the arguments.

Note this could break existing users, but given the script is recent I believe it is still worth improving.
If eval-like behaviour is required one can run `sh -c ...` for identical effect:
```
$ cat /tmp/t.sh
#!/bin/sh

echo --- no eval
"$@"
echo --- eval
eval "$@"
echo ---------------
$ /tmp/t.sh printf "%s\n" "test space"
--- no eval
test space
--- eval
testnspacen---------------
$ /tmp/t.sh sh -c 'printf "%s\n" "test space"'
--- no eval
test space
--- eval
printf: usage: printf [-v var] format [arguments]
---------------
```

Fixes: 4c2893ac2680 ("Add drmSetBackground and drmSetForeground escape codes")



---------------

(for simple commands like just running a session wrapper even with simple arguments this doesn't change anything, it would only break for an user using spaces or quotes)