### PR TITLE
Fix kmscon using 100% CPU when trying to read systemd seats configuration

### DIFF
--- a/src/uterm_monitor.c
+++ b/src/uterm_monitor.c
@@ -100,6 +100,8 @@ static void monitor_refresh_seats(struct uterm_monitor *mon)
 
 	num = uterm_sd_get_seats(mon->sd, &seats);
 	if (num < 0) {
+		/* if it can't read the systemd socket, remove it from the pollfd */
+		ev_eloop_rm_fd(mon->sd_mon_fd);
 		log_warn("cannot read seat information from systemd: %d", num);
 		return;
 	}


### PR DESCRIPTION
When selinux prevents kmscon to read from systemd socket, kmscon uses 100% CPU, because its epoll loop has always a read event on systemd socket, that cannot be cleared.
So remove the fd from the epoll loop, if read returns an error.