### PR TITLE
Set env variable KMS_START_SCRIPT  and TERM_SESSION_TYPE

### DIFF
--- a/src/kmscon_terminal.c
+++ b/src/kmscon_terminal.c
@@ -188,6 +188,19 @@ static void redraw_all(struct kmscon_terminal *term)
 	}
 }
 
+static bool has_kms_display(struct kmscon_terminal *term)
+{
+	struct shl_dlist *iter;
+	struct screen *scr;
+
+	shl_dlist_for_each(iter, &term->screens) {
+		scr = shl_dlist_entry(iter, struct screen, list);
+		if (uterm_display_is_drm(scr->disp))
+			return true;
+	}
+	return false;
+}
+
 static void redraw_all_test(struct kmscon_terminal *term)
 {
 	struct shl_dlist *iter;
@@ -597,7 +610,7 @@ static int terminal_open(struct kmscon_terminal *term)
 	tsm_vte_hard_reset(term->vte);
 	width = tsm_screen_get_width(term->console);
 	height = tsm_screen_get_height(term->console);
-	ret = kmscon_pty_open(term->pty, width, height);
+	ret = kmscon_pty_open(term->pty, width, height, has_kms_display(term));
 	if (ret)
 		return ret;
 

--- a/src/pty.h
+++ b/src/pty.h
@@ -65,7 +65,7 @@ int kmscon_pty_get_fd(struct kmscon_pty *pty);
 void kmscon_pty_dispatch(struct kmscon_pty *pty);
 
 int kmscon_pty_open(struct kmscon_pty *pty, unsigned short width,
-						unsigned short height);
+		    unsigned short height, bool drm);
 void kmscon_pty_close(struct kmscon_pty *pty);
 
 int kmscon_pty_write(struct kmscon_pty *pty, const char *u8, size_t len);

--- a/src/uterm_video.c
+++ b/src/uterm_video.c
@@ -327,6 +327,12 @@ void uterm_display_unbind(struct uterm_display *disp)
 }
 
 SHL_EXPORT
+bool uterm_display_is_drm(struct uterm_display *disp)
+{
+	return (disp->flags & DISPLAY_DITHERING) == 0;
+}
+
+SHL_EXPORT
 struct uterm_display *uterm_display_next(struct uterm_display *disp)
 {
 	if (!disp || !disp->video || disp->list.next == &disp->video->displays)

--- a/src/uterm_video.h
+++ b/src/uterm_video.h
@@ -148,6 +148,7 @@ unsigned int uterm_mode_get_height(const struct uterm_mode *mode);
 
 void uterm_display_ref(struct uterm_display *disp);
 void uterm_display_unref(struct uterm_display *disp);
+bool uterm_display_is_drm(struct uterm_display *disp);
 struct uterm_display *uterm_display_next(struct uterm_display *disp);
 
 int uterm_display_register_cb(struct uterm_display *disp, uterm_display_cb cb,


### PR DESCRIPTION
Set the env variable KMS_START_SCRIPT to "kmscon-launch-gui". This can help scripts like startx or startplasma to work better when launched from kmscon

Fixes #159 