### PR TITLE
print backends

### DIFF
--- a/src/kmscon_terminal.c
+++ b/src/kmscon_terminal.c
@@ -536,6 +536,10 @@ static int add_display(struct kmscon_terminal *term, struct uterm_display *disp)
 
 	shl_dlist_link(&term->screens, &scr->list);
 
+	log_notice("Using video backend [%s] with text renderer [%s] and font engine [%s]",
+		   uterm_display_backend_name(disp), scr->txt->ops->name,
+		   term->font->ops->name);
+
 	log_debug("added display %p to terminal %p", disp, term);
 	redraw_screen(scr);
 	uterm_display_ref(scr->disp);

--- a/src/uterm_video.c
+++ b/src/uterm_video.c
@@ -333,6 +333,14 @@ bool uterm_display_is_drm(struct uterm_display *disp)
 }
 
 SHL_EXPORT
+const char *uterm_display_backend_name(struct uterm_display *disp)
+{
+	if (disp && disp->video && disp->video->mod)
+		return disp->video->mod->name;
+	return "Unknown";
+}
+
+SHL_EXPORT
 struct uterm_display *uterm_display_next(struct uterm_display *disp)
 {
 	if (!disp || !disp->video || disp->list.next == &disp->video->displays)

--- a/src/uterm_video.h
+++ b/src/uterm_video.h
@@ -149,6 +149,7 @@ unsigned int uterm_mode_get_height(const struct uterm_mode *mode);
 void uterm_display_ref(struct uterm_display *disp);
 void uterm_display_unref(struct uterm_display *disp);
 bool uterm_display_is_drm(struct uterm_display *disp);
+const char *uterm_display_backend_name(struct uterm_display *disp);
 struct uterm_display *uterm_display_next(struct uterm_display *disp);
 
 int uterm_display_register_cb(struct uterm_display *disp, uterm_display_cb cb,


### PR DESCRIPTION
Add a log notice, to print the backend that are currently in use for the display.