### PR TITLE
Add Ctrl+Alt+Del reboot functionality with --enable-reboot option

### DIFF
--- a/src/kmscon_conf.c
+++ b/src/kmscon_conf.c
@@ -96,6 +96,8 @@ static void print_help()
 		"\t                              process\n"
 		"\t    --sb-size <num>         [1000]\n"
 		"\t                              Size of the scrollback-buffer in lines\n"
+		"\t    --enable-reboot         [off]\n"
+		"\t                              Enable Ctrl+Alt+Del to reboot system\n"
 		"\n"
 		"Input Options:\n"
 		"\t    --xkb-model <model>        [-]  Set XkbModel for input devices\n"
@@ -725,6 +727,7 @@ int kmscon_conf_new(struct conf_ctx **out)
 		CONF_OPTION_STRING('t', "term", &conf->term, "xterm-256color"),
 		CONF_OPTION_BOOL(0, "reset-env", &conf->reset_env, true),
 		CONF_OPTION_UINT(0, "sb-size", &conf->sb_size, 1000),
+		CONF_OPTION_BOOL(0, "enable-reboot", &conf->enable_reboot, false),
 
 		/* Input Options */
 		CONF_OPTION_STRING(0, "xkb-model", &conf->xkb_model, ""),

--- a/src/kmscon_conf.h
+++ b/src/kmscon_conf.h
@@ -93,6 +93,8 @@ struct kmscon_conf_t {
 	bool reset_env;
 	/* terminal scroll-back buffer size */
 	unsigned int sb_size;
+	/* enable Ctrl+Alt+Del reboot */
+	bool enable_reboot;
 
 	/* Input Options */
 	/* input KBD model */


### PR DESCRIPTION
Add a new command-line option `--enable-reboot` (disabled by default) that enables system reboot via Ctrl+Alt+Del key combination, similar to the behavior of classic text mode consoles.

## Features

When enabled and Ctrl+Alt+Del is pressed:
- Logs an info message about the reboot
- Calls `sync()` to flush filesystem buffers
- Calls `reboot(RB_AUTOBOOT)` to initiate system reboot
- Provides error logging if reboot fails (e.g., insufficient permissions)

## Security considerations

- **Disabled by default** for safety
- Requires explicit `--enable-reboot` flag
- Requires `CAP_SYS_BOOT` capability or root privileges to function
- Creates audit trail via log messages

## Changes

- `src/kmscon_conf.h`: Add `enable_reboot` boolean field to config structure
- `src/kmscon_conf.c`: Register `--enable-reboot` option and help text
- `src/kmscon_terminal.c`: Implement Ctrl+Alt+Del detection and reboot handler

## Usage

```bash
sudo kmscon --enable-reboot
```

Then pressing Ctrl+Alt+Del will reboot the system.
